### PR TITLE
docs: add v2.2.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2026-03-20
+
+### Fixed
+- Release binaries for v2.2.0 (v2.2.0 release was created without build artifacts)
+
 ## [2.2.0] - 2026-03-20
 
 ### Changed


### PR DESCRIPTION
## Summary
- Add v2.2.1 changelog entry for release binary fix
- v2.2.0 release was created without build artifacts; v2.2.1 re-releases with binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)