### PR TITLE
fix: run gqlgenc from repo root in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,9 @@ install: build-cli  ## Install go-linear to $GOPATH/bin
 # Code generation
 #
 
-generate:  ## Run code generation (genqlient)
+generate:  ## Run code generation (gqlgenc)
 	@echo "Running code generation..."
-	@go generate ./...
+	@go run github.com/Yamashou/gqlgenc generate
 	@echo "✓ Code generation complete"
 
 #

--- a/pkg/linear/doc.go
+++ b/pkg/linear/doc.go
@@ -1,5 +1,3 @@
-//go:generate go run github.com/Yamashou/gqlgenc
-
 // Package linear provides a Go client library for the Linear API.
 //
 // The Linear API is a GraphQL API for managing issues, projects, teams,


### PR DESCRIPTION
## Summary
- Remove broken `//go:generate` directive from `doc.go` (gqlgenc ran from `pkg/linear/` but config and schema are at repo root)
- Update Makefile `generate` target to invoke gqlgenc directly from repo root