### PR TITLE
chore: sync with upstream @linear/sdk@80.0.0

### DIFF
--- a/internal/graphql/models.go
+++ b/internal/graphql/models.go
@@ -785,6 +785,8 @@ type AiConversation struct {
 	EvalLogID *string `json:"evalLogId,omitempty"`
 	// The unique identifier of the entity.
 	ID string `json:"id"`
+	// The initial source of the conversation.
+	InitialSource AiConversationInitialSource `json:"initialSource"`
 	// The iteration ID of the conversation in agentic workflow.
 	IterationID *string `json:"iterationId,omitempty"`
 	// The parts of the conversation.
@@ -1161,10 +1163,16 @@ type AiConversationInvokeMcpToolToolCallArgsTool struct {
 
 // Metadata about a part in an AI conversation.
 type AiConversationPartMetadata struct {
+	// The ended timestamp of the part.
+	EndedAt *string `json:"endedAt,omitempty"`
 	// The eval log ID of the part.
 	EvalLogID *string `json:"evalLogId,omitempty"`
 	// AI feedback state for this part.
 	Feedback map[string]any `json:"feedback,omitempty"`
+	// The phase during which the part was generated.
+	Phase *AiConversationPartPhase `json:"phase,omitempty"`
+	// The started timestamp of the part.
+	StartedAt *string `json:"startedAt,omitempty"`
 	// The turn ID of the part.
 	TurnID string `json:"turnId"`
 }
@@ -1372,6 +1380,38 @@ type AiConversationResearchToolCallArgs struct {
 
 type AiConversationResearchToolCallResult struct {
 	ProgressID *string `json:"progressId,omitempty"`
+}
+
+type AiConversationRestoreEntityToolCall struct {
+	// The arguments to the tool call.
+	Args        *AiConversationRestoreEntityToolCallArgs `json:"args,omitempty"`
+	DisplayInfo *AiConversationToolDisplayInfo           `json:"displayInfo"`
+	// The name of the tool that was called.
+	Name AiConversationTool `json:"name"`
+	// The arguments of the tool call.
+	RawArgs *string `json:"rawArgs,omitempty"`
+	// The result of the tool call.
+	RawResult *string `json:"rawResult,omitempty"`
+}
+
+func (AiConversationRestoreEntityToolCall) IsAiConversationBaseToolCall() {}
+func (this AiConversationRestoreEntityToolCall) GetDisplayInfo() *AiConversationToolDisplayInfo {
+	return this.DisplayInfo
+}
+
+// The name of the tool that was called.
+func (this AiConversationRestoreEntityToolCall) GetName() AiConversationTool { return this.Name }
+
+// The arguments of the tool call.
+func (this AiConversationRestoreEntityToolCall) GetRawArgs() *string { return this.RawArgs }
+
+// The result of the tool call.
+func (this AiConversationRestoreEntityToolCall) GetRawResult() *string { return this.RawResult }
+
+func (AiConversationRestoreEntityToolCall) IsAiConversationToolCall() {}
+
+type AiConversationRestoreEntityToolCallArgs struct {
+	Entity *AiConversationSearchEntitiesToolCallResultEntities `json:"entity"`
 }
 
 type AiConversationRetrieveEntitiesToolCall struct {
@@ -1652,7 +1692,8 @@ func (this AiConversationUpdateEntityToolCall) GetRawResult() *string { return t
 func (AiConversationUpdateEntityToolCall) IsAiConversationToolCall() {}
 
 type AiConversationUpdateEntityToolCallArgs struct {
-	Entity *AiConversationSearchEntitiesToolCallResultEntities `json:"entity"`
+	Entities []*AiConversationSearchEntitiesToolCallResultEntities `json:"entities,omitempty"`
+	Entity   *AiConversationSearchEntitiesToolCallResultEntities   `json:"entity,omitempty"`
 }
 
 type AiConversationWebSearchToolCall struct {
@@ -1720,6 +1761,90 @@ func (this AiConversationWidgetPart) GetType() AiConversationPartType { return t
 
 func (AiConversationWidgetPart) IsAiConversationPart() {}
 
+// [Internal] A prompt workflow progress.
+type AiPromptProgress struct {
+	// The time at which the entity was archived. Null if the entity has not been archived.
+	ArchivedAt *time.Time `json:"archivedAt,omitempty"`
+	// The time at which the entity was created.
+	CreatedAt time.Time `json:"createdAt"`
+	// The unique identifier of the entity.
+	ID string `json:"id"`
+	// [Internal] The log ID for the prompt workflow, if available.
+	LogID *string `json:"logId,omitempty"`
+	// [Internal] The metadata for the prompt workflow.
+	Metadata map[string]any `json:"metadata"`
+	// [Internal] The status of the prompt workflow.
+	Status AiPromptProgressStatus `json:"status"`
+	// [Internal] The type of AI prompt workflow.
+	Type AiPromptType `json:"type"`
+	// The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
+	//     been updated after creation.
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+func (AiPromptProgress) IsNode() {}
+
+// The unique identifier of the entity.
+func (this AiPromptProgress) GetID() string { return this.ID }
+
+type AiPromptProgressConnection struct {
+	Edges    []*AiPromptProgressEdge `json:"edges"`
+	Nodes    []*AiPromptProgress     `json:"nodes"`
+	PageInfo *PageInfo               `json:"pageInfo"`
+}
+
+type AiPromptProgressEdge struct {
+	// Used in `before` and `after` args
+	Cursor string            `json:"cursor"`
+	Node   *AiPromptProgress `json:"node"`
+}
+
+// [Internal] AI prompt progress filtering options.
+type AiPromptProgressFilter struct {
+	// [Internal] Compound filters, all of which need to be matched by the AI prompt progress.
+	And []*AiPromptProgressFilter `json:"and,omitempty"`
+	// Comparator for the created at date.
+	CreatedAt *DateComparator `json:"createdAt,omitempty"`
+	// Comparator for the identifier.
+	ID *IDComparator `json:"id,omitempty"`
+	// [Internal] Compound filters, one of which need to be matched by the AI prompt progress.
+	Or []*AiPromptProgressFilter `json:"or,omitempty"`
+	// [Internal] Comparator for the AI prompt workflow status.
+	Status *AiPromptProgressStatusComparator `json:"status,omitempty"`
+	// [Internal] Comparator for the AI prompt workflow type.
+	Type *AiPromptTypeComparator `json:"type,omitempty"`
+	// Comparator for the updated at date.
+	UpdatedAt *DateComparator `json:"updatedAt,omitempty"`
+}
+
+// [Internal] Comparator for the AI prompt workflow status.
+type AiPromptProgressStatusComparator struct {
+	// Equals constraint.
+	Eq *AiPromptProgressStatus `json:"eq,omitempty"`
+	// In-array constraint.
+	In []AiPromptProgressStatus `json:"in,omitempty"`
+	// Not-equals constraint.
+	Neq *AiPromptProgressStatus `json:"neq,omitempty"`
+	// Not-in-array constraint.
+	Nin []AiPromptProgressStatus `json:"nin,omitempty"`
+	// Null constraint. Matches any non-null values if the given value is false, otherwise it matches null values.
+	Null *bool `json:"null,omitempty"`
+}
+
+// [Internal] Filter for AI prompt progress subscription events.
+type AiPromptProgressSubscriptionFilter struct {
+	// [Internal] Filter by comment ID.
+	CommentID *IDComparator `json:"commentId,omitempty"`
+	// [Internal] Filter by issue ID.
+	IssueID *IDComparator `json:"issueId,omitempty"`
+	// [Internal] Filter by pull request comment ID.
+	PullRequestCommentID *IDComparator `json:"pullRequestCommentId,omitempty"`
+	// [Internal] Filter by prompt workflow status.
+	Status *AiPromptProgressStatusComparator `json:"status,omitempty"`
+	// [Internal] Filter by prompt workflow type.
+	Type *AiPromptTypeComparator `json:"type,omitempty"`
+}
+
 // AI prompt rules for a team.
 type AiPromptRules struct {
 	// The time at which the entity was archived. Null if the entity has not been archived.
@@ -1739,6 +1864,20 @@ func (AiPromptRules) IsNode() {}
 
 // The unique identifier of the entity.
 func (this AiPromptRules) GetID() string { return this.ID }
+
+// [Internal] Comparator for the AI prompt workflow type.
+type AiPromptTypeComparator struct {
+	// Equals constraint.
+	Eq *AiPromptType `json:"eq,omitempty"`
+	// In-array constraint.
+	In []AiPromptType `json:"in,omitempty"`
+	// Not-equals constraint.
+	Neq *AiPromptType `json:"neq,omitempty"`
+	// Not-in-array constraint.
+	Nin []AiPromptType `json:"nin,omitempty"`
+	// Null constraint. Matches any non-null values if the given value is false, otherwise it matches null values.
+	Null *bool `json:"null,omitempty"`
+}
 
 type AirbyteConfigurationInput struct {
 	// Linear export API key.
@@ -2184,6 +2323,8 @@ type AuthOrganization struct {
 	AllowedAuthServices []string `json:"allowedAuthServices"`
 	// An approximate count of users, updated once per day.
 	ApproximateUserCount float64 `json:"approximateUserCount"`
+	// Authentication settings for the organization.
+	AuthSettings map[string]any `json:"authSettings"`
 	// The time at which the entity was created.
 	CreatedAt time.Time `json:"createdAt"`
 	// The time at which deletion of the organization was requested.
@@ -2361,16 +2502,20 @@ type CodingAgentSandboxPayload struct {
 	SandboxURL *string `json:"sandboxUrl,omitempty"`
 	// When the sandbox first became active.
 	StartedAt *time.Time `json:"startedAt,omitempty"`
+	// Temporal URL to view all workflows for this sandbox.
+	TemporalWorkflowURL *string `json:"temporalWorkflowUrl,omitempty"`
 	// Claude Agent SDK conversation ID.
 	WorkerConversationID *string `json:"workerConversationId,omitempty"`
 }
 
-// A comment associated with an issue.
+// A comment associated with an entity.
 type Comment struct {
 	// Agent session associated with this comment.
 	AgentSession *AgentSession `json:"agentSession,omitempty"`
 	// [Internal] Agent sessions associated with this comment.
 	AgentSessions *AgentSessionConnection `json:"agentSessions"`
+	// [Internal] AI prompt progresses associated with this comment.
+	AiPromptProgresses *AiPromptProgressConnection `json:"aiPromptProgresses"`
 	// The time at which the entity was archived. Null if the entity has not been archived.
 	ArchivedAt *time.Time `json:"archivedAt,omitempty"`
 	// The comment content in markdown format.
@@ -2399,6 +2544,10 @@ type Comment struct {
 	HideInLinear bool `json:"hideInLinear"`
 	// The unique identifier of the entity.
 	ID string `json:"id"`
+	// [Internal] The initiative that the comment is associated with.
+	Initiative *Initiative `json:"initiative,omitempty"`
+	// [Internal] The ID of the initiative that the comment is associated with.
+	InitiativeID *string `json:"initiativeId,omitempty"`
 	// The initiative update that the comment is associated with.
 	InitiativeUpdate *InitiativeUpdate `json:"initiativeUpdate,omitempty"`
 	// The ID of the initiative update that the comment is associated with.
@@ -2417,6 +2566,10 @@ type Comment struct {
 	ParentID *string `json:"parentId,omitempty"`
 	// The post that the comment is associated with.
 	Post *Post `json:"post,omitempty"`
+	// [Internal] The project that the comment is associated with.
+	Project *Project `json:"project,omitempty"`
+	// [Internal] The ID of the project that the comment is associated with.
+	ProjectID *string `json:"projectId,omitempty"`
 	// The project update that the comment is associated with.
 	ProjectUpdate *ProjectUpdate `json:"projectUpdate,omitempty"`
 	// The ID of the project update that the comment is associated with.
@@ -2463,10 +2616,14 @@ type CommentChildWebhookPayload struct {
 	DocumentContentID *string `json:"documentContentId,omitempty"`
 	// The ID of the comment.
 	ID string `json:"id"`
+	// [Internal] The ID of the initiative this comment belongs to.
+	InitiativeID *string `json:"initiativeId,omitempty"`
 	// The ID of the initiative update this comment belongs to.
 	InitiativeUpdateID *string `json:"initiativeUpdateId,omitempty"`
 	// The ID of the issue this comment belongs to.
 	IssueID *string `json:"issueId,omitempty"`
+	// [Internal] The ID of the project this comment belongs to.
+	ProjectID *string `json:"projectId,omitempty"`
 	// The ID of the project update this comment belongs to.
 	ProjectUpdateID *string `json:"projectUpdateId,omitempty"`
 	// The ID of the user who created this comment.
@@ -2487,6 +2644,8 @@ type CommentCollectionFilter struct {
 	Every *CommentFilter `json:"every,omitempty"`
 	// Comparator for the identifier.
 	ID *IDComparator `json:"id,omitempty"`
+	// [Internal] Filters that the comment's initiative must satisfy.
+	Initiative *NullableInitiativeFilter `json:"initiative,omitempty"`
 	// Filters that the comment's issue must satisfy.
 	Issue *NullableIssueFilter `json:"issue,omitempty"`
 	// Comparator for the collection length.
@@ -2497,6 +2656,8 @@ type CommentCollectionFilter struct {
 	Or []*CommentCollectionFilter `json:"or,omitempty"`
 	// Filters that the comment parent must satisfy.
 	Parent *NullableCommentFilter `json:"parent,omitempty"`
+	// [Internal] Filters that the comment's project must satisfy.
+	Project *NullableProjectFilter `json:"project,omitempty"`
 	// Filters that the comment's project update must satisfy.
 	ProjectUpdate *NullableProjectUpdateFilter `json:"projectUpdate,omitempty"`
 	// Filters that the comment's reactions must satisfy.
@@ -2534,6 +2695,8 @@ type CommentCreateInput struct {
 	DocumentContentID *string `json:"documentContentId,omitempty"`
 	// The identifier in UUID v4 format. If none is provided, the backend will generate one.
 	ID *string `json:"id,omitempty"`
+	// [Internal] The initiative to associate the comment with.
+	InitiativeID *string `json:"initiativeId,omitempty"`
 	// The initiative update to associate the comment with.
 	InitiativeUpdateID *string `json:"initiativeUpdateId,omitempty"`
 	// The issue to associate the comment with. Can be a UUID or issue identifier (e.g., 'LIN-123').
@@ -2542,6 +2705,8 @@ type CommentCreateInput struct {
 	ParentID *string `json:"parentId,omitempty"`
 	// The post to associate the comment with.
 	PostID *string `json:"postId,omitempty"`
+	// [Internal] The project to associate the comment with.
+	ProjectID *string `json:"projectId,omitempty"`
 	// The project update to associate the comment with.
 	ProjectUpdateID *string `json:"projectUpdateId,omitempty"`
 	// The text that this comment references. Only defined for inline comments.
@@ -2568,6 +2733,8 @@ type CommentFilter struct {
 	DocumentContent *NullableDocumentContentFilter `json:"documentContent,omitempty"`
 	// Comparator for the identifier.
 	ID *IDComparator `json:"id,omitempty"`
+	// [Internal] Filters that the comment's initiative must satisfy.
+	Initiative *NullableInitiativeFilter `json:"initiative,omitempty"`
 	// Filters that the comment's issue must satisfy.
 	Issue *NullableIssueFilter `json:"issue,omitempty"`
 	// Filters that the comment's customer needs must satisfy.
@@ -2576,6 +2743,8 @@ type CommentFilter struct {
 	Or []*CommentFilter `json:"or,omitempty"`
 	// Filters that the comment parent must satisfy.
 	Parent *NullableCommentFilter `json:"parent,omitempty"`
+	// [Internal] Filters that the comment's project must satisfy.
+	Project *NullableProjectFilter `json:"project,omitempty"`
 	// Filters that the comment's project update must satisfy.
 	ProjectUpdate *NullableProjectUpdateFilter `json:"projectUpdate,omitempty"`
 	// Filters that the comment's reactions must satisfy.
@@ -2634,6 +2803,8 @@ type CommentWebhookPayload struct {
 	ExternalUserID *string `json:"externalUserId,omitempty"`
 	// The ID of the entity.
 	ID string `json:"id"`
+	// [Internal] The ID of the initiative this comment belongs to.
+	InitiativeID *string `json:"initiativeId,omitempty"`
 	// The initiative update this comment belongs to.
 	InitiativeUpdate *InitiativeUpdateChildWebhookPayload `json:"initiativeUpdate,omitempty"`
 	// The ID of the initiative update this comment belongs to.
@@ -2648,6 +2819,8 @@ type CommentWebhookPayload struct {
 	ParentID *string `json:"parentId,omitempty"`
 	// The ID of the post this comment belongs to.
 	PostID *string `json:"postId,omitempty"`
+	// [Internal] The ID of the project this comment belongs to.
+	ProjectID *string `json:"projectId,omitempty"`
 	// The project update this comment belongs to.
 	ProjectUpdate *ProjectUpdateChildWebhookPayload `json:"projectUpdate,omitempty"`
 	// The ID of the project update this comment belongs to.
@@ -4892,6 +5065,8 @@ type Document struct {
 	SlugID string `json:"slugId"`
 	// The order of the item in the resources list.
 	SortOrder float64 `json:"sortOrder"`
+	// [Internal] A one-sentence AI-generated summary of the document content.
+	Summary *string `json:"summary,omitempty"`
 	// [Internal] The team that the document is associated with.
 	Team *Team `json:"team,omitempty"`
 	// The document title.
@@ -5000,6 +5175,30 @@ type DocumentContentChildWebhookPayload struct {
 	Project *ProjectChildWebhookPayload `json:"project,omitempty"`
 }
 
+// A draft revision of document content, pending user review.
+type DocumentContentDraft struct {
+	// The time at which the entity was archived. Null if the entity has not been archived.
+	ArchivedAt *time.Time `json:"archivedAt,omitempty"`
+	// The draft content state as a base64 encoded Yjs state update.
+	ContentState string `json:"contentState"`
+	// The time at which the entity was created.
+	CreatedAt         time.Time        `json:"createdAt"`
+	DocumentContent   *DocumentContent `json:"documentContent"`
+	DocumentContentID string           `json:"documentContentId"`
+	// The unique identifier of the entity.
+	ID string `json:"id"`
+	// The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
+	//     been updated after creation.
+	UpdatedAt time.Time `json:"updatedAt"`
+	User      *User     `json:"user"`
+	UserID    string    `json:"userId"`
+}
+
+func (DocumentContentDraft) IsNode() {}
+
+// The unique identifier of the entity.
+func (this DocumentContentDraft) GetID() string { return this.ID }
+
 type DocumentContentHistoryPayload struct {
 	// The document content history entries.
 	History []*DocumentContentHistoryType `json:"history"`
@@ -5069,6 +5268,8 @@ type DocumentFilter struct {
 	CreatedAt *DateComparator `json:"createdAt,omitempty"`
 	// Filters that the document's creator must satisfy.
 	Creator *UserFilter `json:"creator,omitempty"`
+	// Filters that the document's cycle must satisfy.
+	Cycle *CycleFilter `json:"cycle,omitempty"`
 	// Comparator for the identifier.
 	ID *IDComparator `json:"id,omitempty"`
 	// Filters that the document's initiative must satisfy.
@@ -5079,6 +5280,8 @@ type DocumentFilter struct {
 	Or []*DocumentFilter `json:"or,omitempty"`
 	// Filters that the document's project must satisfy.
 	Project *ProjectFilter `json:"project,omitempty"`
+	// Filters that the document's release must satisfy.
+	Release *ReleaseFilter `json:"release,omitempty"`
 	// Comparator for the document slug ID.
 	SlugID *StringComparator `json:"slugId,omitempty"`
 	// Comparator for the document title.
@@ -5319,6 +5522,8 @@ type DocumentSearchResult struct {
 	SlugID string `json:"slugId"`
 	// The order of the item in the resources list.
 	SortOrder float64 `json:"sortOrder"`
+	// [Internal] A one-sentence AI-generated summary of the document content.
+	Summary *string `json:"summary,omitempty"`
 	// [Internal] The team that the document is associated with.
 	Team *Team `json:"team,omitempty"`
 	// The document title.
@@ -5442,7 +5647,7 @@ type Draft struct {
 	Data map[string]any `json:"data,omitempty"`
 	// The unique identifier of the entity.
 	ID string `json:"id"`
-	// The initiative for which this is a draft initiative update.
+	// The initiative for which this is a draft comment or initiative update.
 	Initiative *Initiative `json:"initiative,omitempty"`
 	// The initiative update for which this is a draft comment.
 	InitiativeUpdate *InitiativeUpdate `json:"initiativeUpdate,omitempty"`
@@ -5454,7 +5659,7 @@ type Draft struct {
 	ParentComment *Comment `json:"parentComment,omitempty"`
 	// The post for which this is a draft comment.
 	Post *Post `json:"post,omitempty"`
-	// The project for which this is a draft project update.
+	// The project for which this is a draft comment or project update.
 	Project *Project `json:"project,omitempty"`
 	// The project update for which this is a draft comment.
 	ProjectUpdate *ProjectUpdate `json:"projectUpdate,omitempty"`
@@ -5656,6 +5861,8 @@ type EmailUserAccountAuthChallengeInput struct {
 	IsDesktop *bool `json:"isDesktop,omitempty"`
 	// Whether to only return the login code. This is used by mobile apps to skip showing the login link.
 	LoginCodeOnly *bool `json:"loginCodeOnly,omitempty"`
+	// PostHog session ID for attribution tracking.
+	SessionID *string `json:"sessionId,omitempty"`
 }
 
 type EmailUserAccountAuthChallengeResponse struct {
@@ -6473,6 +6680,8 @@ type GitHubPersonalSettingsInput struct {
 type GitHubRepoInput struct {
 	// Whether the repository is archived.
 	Archived *bool `json:"archived,omitempty"`
+	// The external identifier (GitHub node ID) for the repository.
+	ExternalID *string `json:"externalId,omitempty"`
 	// The full name of the repository.
 	FullName string `json:"fullName"`
 	// The GitHub repo id.
@@ -6499,6 +6708,8 @@ type GitHubSettingsInput struct {
 	CodeAccess *bool `json:"codeAccess,omitempty"`
 	// The enterprise URL if this is a GitHub Enterprise Cloud integration.
 	EnterpriseURL *string `json:"enterpriseUrl,omitempty"`
+	// The stable external identifier (GitHub node ID) for the organization.
+	ExternalOrgID *string `json:"externalOrgId,omitempty"`
 	// The avatar URL for the GitHub organization.
 	OrgAvatarURL *string `json:"orgAvatarUrl,omitempty"`
 	// The GitHub organization's name.
@@ -6602,6 +6813,8 @@ type GoogleUserAccountAuthInput struct {
 	InviteLink *string `json:"inviteLink,omitempty"`
 	// The URI to redirect the user to.
 	RedirectURI *string `json:"redirectUri,omitempty"`
+	// PostHog session ID for attribution tracking.
+	SessionID *string `json:"sessionId,omitempty"`
 	// The timezone of the user's browser.
 	Timezone string `json:"timezone"`
 }
@@ -10141,6 +10354,18 @@ type IssueStatusChangedNotificationWebhookPayload struct {
 
 func (IssueStatusChangedNotificationWebhookPayload) IsNotificationWebhookPayload() {}
 
+// Filter for issue subscription events.
+type IssueSubscriptionFilter struct {
+	// Filter by assignee ID.
+	AssigneeID *IDComparator `json:"assigneeId,omitempty"`
+	// Filter by project ID.
+	ProjectID *IDComparator `json:"projectId,omitempty"`
+	// Filter by workflow state ID.
+	StateID *IDComparator `json:"stateId,omitempty"`
+	// Filter by team ID.
+	TeamID *IDComparator `json:"teamId,omitempty"`
+}
+
 type IssueSuggestion struct {
 	// The time at which the entity was archived. Null if the entity has not been archived.
 	ArchivedAt *time.Time `json:"archivedAt,omitempty"`
@@ -10595,6 +10820,8 @@ type JiraLinearMappingInput struct {
 	Default *bool `json:"default,omitempty"`
 	// The Jira id for this project.
 	JiraProjectID string `json:"jiraProjectId"`
+	// Whether this mapping uses legacy unidirectional sync behavior where no changes sync from Linear to Jira.
+	LegacyUnidirectional *bool `json:"legacyUnidirectional,omitempty"`
 	// The Linear team id to map to the given project.
 	LinearTeamID string `json:"linearTeamId"`
 }
@@ -11162,6 +11389,8 @@ type NullableCommentFilter struct {
 	DocumentContent *NullableDocumentContentFilter `json:"documentContent,omitempty"`
 	// Comparator for the identifier.
 	ID *IDComparator `json:"id,omitempty"`
+	// [Internal] Filters that the comment's initiative must satisfy.
+	Initiative *NullableInitiativeFilter `json:"initiative,omitempty"`
 	// Filters that the comment's issue must satisfy.
 	Issue *NullableIssueFilter `json:"issue,omitempty"`
 	// Filters that the comment's customer needs must satisfy.
@@ -11172,6 +11401,8 @@ type NullableCommentFilter struct {
 	Or []*NullableCommentFilter `json:"or,omitempty"`
 	// Filters that the comment parent must satisfy.
 	Parent *NullableCommentFilter `json:"parent,omitempty"`
+	// [Internal] Filters that the comment's project must satisfy.
+	Project *NullableProjectFilter `json:"project,omitempty"`
 	// Filters that the comment's project update must satisfy.
 	ProjectUpdate *NullableProjectUpdateFilter `json:"projectUpdate,omitempty"`
 	// Filters that the comment's reactions must satisfy.
@@ -11326,6 +11557,50 @@ type NullableDurationComparator struct {
 	Nin []string `json:"nin,omitempty"`
 	// Null constraint. Matches any non-null values if the given value is false, otherwise it matches null values.
 	Null *bool `json:"null,omitempty"`
+}
+
+// Initiative filtering options.
+type NullableInitiativeFilter struct {
+	// Comparator for the initiative activity type.
+	ActivityType *StringComparator `json:"activityType,omitempty"`
+	// Filters that the initiative must be an ancestor of.
+	Ancestors *InitiativeCollectionFilter `json:"ancestors,omitempty"`
+	// Compound filters, all of which need to be matched by the initiative.
+	And []*NullableInitiativeFilter `json:"and,omitempty"`
+	// Comparator for the initiative completed at date.
+	CompletedAt *NullableDateComparator `json:"completedAt,omitempty"`
+	// Comparator for the created at date.
+	CreatedAt *DateComparator `json:"createdAt,omitempty"`
+	// Filters that the initiative creator must satisfy.
+	Creator *NullableUserFilter `json:"creator,omitempty"`
+	// Comparator for the initiative health: onTrack, atRisk, offTrack
+	Health *StringComparator `json:"health,omitempty"`
+	// Comparator for the initiative health (with age): onTrack, atRisk, offTrack, outdated, noUpdate
+	HealthWithAge *StringComparator `json:"healthWithAge,omitempty"`
+	// Comparator for the identifier.
+	ID *IDComparator `json:"id,omitempty"`
+	// Filters that the initiative updates must satisfy.
+	InitiativeUpdates *InitiativeUpdatesCollectionFilter `json:"initiativeUpdates,omitempty"`
+	// Comparator for the initiative name.
+	Name *StringComparator `json:"name,omitempty"`
+	// Filter based on the existence of the relation.
+	Null *bool `json:"null,omitempty"`
+	// Compound filters, one of which need to be matched by the initiative.
+	Or []*NullableInitiativeFilter `json:"or,omitempty"`
+	// Filters that the initiative owner must satisfy.
+	Owner *NullableUserFilter `json:"owner,omitempty"`
+	// Comparator for the initiative slug ID.
+	SlugID *StringComparator `json:"slugId,omitempty"`
+	// Comparator for the initiative started at date.
+	StartedAt *NullableDateComparator `json:"startedAt,omitempty"`
+	// Comparator for the initiative status: Planned, Active, Completed
+	Status *StringComparator `json:"status,omitempty"`
+	// Comparator for the initiative target date.
+	TargetDate *NullableDateComparator `json:"targetDate,omitempty"`
+	// Filters that the initiative teams must satisfy.
+	Teams *TeamCollectionFilter `json:"teams,omitempty"`
+	// Comparator for the updated at date.
+	UpdatedAt *DateComparator `json:"updatedAt,omitempty"`
 }
 
 // Issue filtering options.
@@ -12076,6 +12351,8 @@ type OpsgenieInput struct {
 
 // An organization. Organizations are root-level objects that contain user accounts and teams.
 type Organization struct {
+	// [INTERNAL] Whether the organization has enabled agent automation.
+	AgentAutomationEnabled bool `json:"agentAutomationEnabled"`
 	// [INTERNAL] Whether the organization has enabled the AI add-on (which at this point only includes triage suggestions).
 	AiAddonEnabled bool `json:"aiAddonEnabled"`
 	// Whether the organization has enabled AI discussion summaries for issues.
@@ -12094,10 +12371,14 @@ type Organization struct {
 	AllowedFileUploadContentTypes []string `json:"allowedFileUploadContentTypes,omitempty"`
 	// The time at which the entity was archived. Null if the entity has not been archived.
 	ArchivedAt *time.Time `json:"archivedAt,omitempty"`
+	// Authentication settings for the organization.
+	AuthSettings map[string]any `json:"authSettings"`
 	// [INTERNAL] Whether code intelligence is enabled for the organization.
 	CodeIntelligenceEnabled bool `json:"codeIntelligenceEnabled"`
 	// [INTERNAL] GitHub repository in owner/repo format for code intelligence.
 	CodeIntelligenceRepository *string `json:"codeIntelligenceRepository,omitempty"`
+	// [INTERNAL] Whether the organization has enabled the Coding Agent.
+	CodingAgentEnabled bool `json:"codingAgentEnabled"`
 	// The time at which the entity was created.
 	CreatedAt time.Time `json:"createdAt"`
 	// Aproximate number of issues in the organization, including archived ones.
@@ -12148,6 +12429,8 @@ type Organization struct {
 	Labels *IssueLabelConnection `json:"labels"`
 	// [Internal] Whether the organization has enabled Linear Agent.
 	LinearAgentEnabled bool `json:"linearAgentEnabled"`
+	// [Internal] Settings for Linear Agent features.
+	LinearAgentSettings map[string]any `json:"linearAgentSettings"`
 	// The organization's logo URL.
 	LogoURL *string `json:"logoUrl,omitempty"`
 	// The organization's name.
@@ -12230,6 +12513,17 @@ type OrganizationAcceptedOrExpiredInviteDetailsPayload struct {
 }
 
 func (OrganizationAcceptedOrExpiredInviteDetailsPayload) IsOrganizationInviteDetailsPayload() {}
+
+type OrganizationAuthSettingsInput struct {
+	// [Internal] The minimum role required for the auth service bypass exemption.
+	AllowedAuthServiceBypassRole *string `json:"allowedAuthServiceBypassRole,omitempty"`
+	// Allowed authentication providers, empty array means all are allowed.
+	AllowedAuthServices []string `json:"allowedAuthServices,omitempty"`
+	// Whether to disable admin/owner auth service bypass.
+	DisableAuthServiceBypass *bool `json:"disableAuthServiceBypass,omitempty"`
+	// Whether to hide non-primary organizations during signup for users with matching email domains.
+	HideNonPrimaryOrganizations *bool `json:"hideNonPrimaryOrganizations,omitempty"`
+}
 
 type OrganizationCancelDeletePayload struct {
 	// Whether the operation was successful.
@@ -12454,6 +12748,20 @@ type OrganizationIPRestrictionInput struct {
 	Type string `json:"type"`
 }
 
+type OrganizationLinearAgentMcpServerAllowlistEntryInput struct {
+	// [Internal] The MCP server URL that Linear Agent is allowed to use.
+	URL string `json:"url"`
+}
+
+type OrganizationLinearAgentSettingsInput struct {
+	// [Internal] The MCP server allowlist for Linear Agent. When unset, all MCP servers are allowed.
+	McpServersAllowlist []*OrganizationLinearAgentMcpServerAllowlistEntryInput `json:"mcpServersAllowlist,omitempty"`
+	// [Internal] Whether the organization has enabled MCP servers for Linear Agent.
+	McpServersEnabled *bool `json:"mcpServersEnabled,omitempty"`
+	// [Internal] Whether the organization has enabled web search for Linear Agent.
+	WebSearchEnabled *bool `json:"webSearchEnabled,omitempty"`
+}
+
 type OrganizationMeta struct {
 	// Allowed authentication providers, empty array means all are allowed.
 	AllowedAuthServices []string `json:"allowedAuthServices"`
@@ -12510,6 +12818,8 @@ type OrganizationStartTrialPayload struct {
 }
 
 type OrganizationUpdateInput struct {
+	// [INTERNAL] Whether the organization has enabled agent automation.
+	AgentAutomationEnabled *bool `json:"agentAutomationEnabled,omitempty"`
 	// [INTERNAL] Whether the organization has enabled the AI add-on.
 	AiAddonEnabled *bool `json:"aiAddonEnabled,omitempty"`
 	// Whether the organization has enabled AI discussion summaries for issues.
@@ -12524,10 +12834,14 @@ type OrganizationUpdateInput struct {
 	AllowedAuthServices []string `json:"allowedAuthServices,omitempty"`
 	// Allowed file upload content types.
 	AllowedFileUploadContentTypes []string `json:"allowedFileUploadContentTypes,omitempty"`
+	// The authentication settings for the organization.
+	AuthSettings *OrganizationAuthSettingsInput `json:"authSettings,omitempty"`
 	// [INTERNAL] Whether code intelligence is enabled for the organization.
 	CodeIntelligenceEnabled *bool `json:"codeIntelligenceEnabled,omitempty"`
 	// [INTERNAL] GitHub repository in owner/repo format for code intelligence.
 	CodeIntelligenceRepository *string `json:"codeIntelligenceRepository,omitempty"`
+	// [INTERNAL] Whether the organization has enabled the Coding Agent.
+	CodingAgentEnabled *bool `json:"codingAgentEnabled,omitempty"`
 	// [INTERNAL] Configuration settings for the Customers feature.
 	CustomersConfiguration map[string]any `json:"customersConfiguration,omitempty"`
 	// [INTERNAL] Whether the organization is using customers.
@@ -12562,6 +12876,8 @@ type OrganizationUpdateInput struct {
 	IPRestrictions []*OrganizationIPRestrictionInput `json:"ipRestrictions,omitempty"`
 	// [Internal] Whether the organization has enabled Linear Agent.
 	LinearAgentEnabled *bool `json:"linearAgentEnabled,omitempty"`
+	// [Internal] Settings for Linear Agent features.
+	LinearAgentSettings *OrganizationLinearAgentSettingsInput `json:"linearAgentSettings,omitempty"`
 	// The logo of the organization.
 	LogoURL *string `json:"logoUrl,omitempty"`
 	// The name of the organization.
@@ -15067,6 +15383,8 @@ func (ProjectWebhookPayload) IsDataWebhookPayload() {}
 type PullRequest struct {
 	// The time at which the entity was archived. Null if the entity has not been archived.
 	ArchivedAt *time.Time `json:"archivedAt,omitempty"`
+	// The base SHA of the pull request.
+	BaseSha *string `json:"baseSha,omitempty"`
 	// [Internal] The checks associated with the pull request.
 	Checks []*PullRequestCheck `json:"checks"`
 	// [ALPHA] The commits associated with the pull request.
@@ -15075,6 +15393,8 @@ type PullRequest struct {
 	CreatedAt time.Time `json:"createdAt"`
 	// [Internal] The user who created the pull request.
 	Creator *User `json:"creator,omitempty"`
+	// The head SHA of the pull request.
+	HeadSha *string `json:"headSha,omitempty"`
 	// The unique identifier of the entity.
 	ID string `json:"id"`
 	// The merge commit created when the PR was merged.
@@ -15113,6 +15433,8 @@ type PullRequestCheck struct {
 	IsRequired *bool `json:"isRequired,omitempty"`
 	// The name of the check.
 	Name string `json:"name"`
+	// How the check should be opened in the client.
+	Presentation *PullRequestCheckPresentation `json:"presentation,omitempty"`
 	// The date/time at which when the check was started.
 	StartedAt *time.Time `json:"startedAt,omitempty"`
 	// The status of the check.
@@ -15583,6 +15905,10 @@ type Release struct {
 	Documents *DocumentConnection `json:"documents"`
 	// The unique identifier of the entity.
 	ID string `json:"id"`
+	// [ALPHA] Number of issues associated with the release.
+	IssueCount int64 `json:"issueCount"`
+	// [ALPHA] Issues associated with the release.
+	Issues *IssueConnection `json:"issues"`
 	// [Internal] Links associated with the release.
 	Links *EntityExternalLinkConnection `json:"links"`
 	// The name of the release.
@@ -15778,11 +16104,15 @@ type ReleasePipeline struct {
 	SlugID string `json:"slugId"`
 	// [ALPHA] Stages associated with this pipeline.
 	Stages *ReleaseStageConnection `json:"stages"`
+	// [ALPHA] Teams associated with this pipeline.
+	Teams *TeamConnection `json:"teams"`
 	// The type of the pipeline.
 	Type ReleasePipelineType `json:"type"`
 	// The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
 	//     been updated after creation.
 	UpdatedAt time.Time `json:"updatedAt"`
+	// [Internal] Release pipeline URL.
+	URL string `json:"url"`
 }
 
 func (ReleasePipeline) IsNode() {}
@@ -15823,6 +16153,8 @@ type ReleasePipelineCreateInput struct {
 	Name string `json:"name"`
 	// The pipeline's unique slug identifier. If not provided, it will be auto-generated.
 	SlugID *string `json:"slugId,omitempty"`
+	// The identifiers of the teams this pipeline is associated with.
+	TeamIds []string `json:"teamIds,omitempty"`
 	// The type of the pipeline.
 	Type *ReleasePipelineType `json:"type,omitempty"`
 }
@@ -15865,8 +16197,16 @@ type ReleasePipelineUpdateInput struct {
 	Name *string `json:"name,omitempty"`
 	// The pipeline's unique slug identifier.
 	SlugID *string `json:"slugId,omitempty"`
+	// The identifiers of the teams this pipeline is associated with.
+	TeamIds []string `json:"teamIds,omitempty"`
 	// The type of the pipeline.
 	Type *ReleasePipelineType `json:"type,omitempty"`
+}
+
+// Release sorting options.
+type ReleaseSortInput struct {
+	// Sort by release stage
+	Stage *ReleaseStageSort `json:"stage,omitempty"`
 }
 
 // [Internal] A release stage.
@@ -15973,6 +16313,14 @@ type ReleaseStagePayload struct {
 	ReleaseStage *ReleaseStage `json:"releaseStage"`
 	// Whether the operation was successful.
 	Success bool `json:"success"`
+}
+
+// Release stage sorting options.
+type ReleaseStageSort struct {
+	// Whether nulls should be sorted first or last
+	Nulls *PaginationNulls `json:"nulls,omitempty"`
+	// The order for the individual sort
+	Order *PaginationSortOrder `json:"order,omitempty"`
 }
 
 // [ALPHA] Comparator for release stage type.
@@ -16650,14 +16998,6 @@ type SlackSettingsInput struct {
 
 // Comparator for issue source type.
 type SourceMetadataComparator struct {
-	// Equals constraint.
-	Eq *string `json:"eq,omitempty"`
-	// In-array constraint.
-	In []string `json:"in,omitempty"`
-	// Not-equals constraint.
-	Neq *string `json:"neq,omitempty"`
-	// Not-in-array constraint.
-	Nin []string `json:"nin,omitempty"`
 	// Null constraint. Matches any non-null values if the given value is false, otherwise it matches null values.
 	Null *bool `json:"null,omitempty"`
 	// [INTERNAL] Comparator for the salesforce metadata.
@@ -16811,6 +17151,9 @@ type SubTypeComparator struct {
 	Nin []string `json:"nin,omitempty"`
 	// Null constraint. Matches any non-null values if the given value is false, otherwise it matches null values.
 	Null *bool `json:"null,omitempty"`
+}
+
+type Subscription struct {
 }
 
 type SuccessPayload struct {
@@ -16999,7 +17342,7 @@ type Team struct {
 	Name string `json:"name"`
 	// The organization that the team is associated with.
 	Organization *Organization `json:"organization"`
-	// [Internal] The team's parent team.
+	// The team's parent team.
 	Parent *Team `json:"parent,omitempty"`
 	// [Internal] Posts associated with the team.
 	Posts []*Post `json:"posts"`
@@ -17166,6 +17509,8 @@ type TeamCreateInput struct {
 	IssueEstimationExtended *bool `json:"issueEstimationExtended,omitempty"`
 	// The issue estimation type to use. Must be one of "notUsed", "exponential", "fibonacci", "linear", "tShirt".
 	IssueEstimationType *string `json:"issueEstimationType,omitempty"`
+	// The policy controlling whether and by whom issues in the team can be shared with non-team-members.
+	IssueSharingPolicy *IssueSharingPolicy `json:"issueSharingPolicy,omitempty"`
 	// The key of the team. If not given, the key will be generated based on the name of the team.
 	Key *string `json:"key,omitempty"`
 	// The workflow state into which issues are moved when they are marked as a duplicate of another issue.
@@ -17504,6 +17849,8 @@ type TeamUpdateInput struct {
 	IssueEstimationExtended *bool `json:"issueEstimationExtended,omitempty"`
 	// The issue estimation type to use. Must be one of "notUsed", "exponential", "fibonacci", "linear", "tShirt".
 	IssueEstimationType *string `json:"issueEstimationType,omitempty"`
+	// The policy controlling whether and by whom issues in the team can be shared with non-team-members.
+	IssueSharingPolicy *IssueSharingPolicy `json:"issueSharingPolicy,omitempty"`
 	// Whether new users should join this team by default. Mutation restricted to workspace admins or owners!
 	JoinByDefault *bool `json:"joinByDefault,omitempty"`
 	// The key of the team.
@@ -18651,6 +18998,12 @@ type ViewPreferencesValues struct {
 	FieldStatus *bool `json:"fieldStatus,omitempty"`
 	// Whether to show the time in current status field.
 	FieldTimeInCurrentStatus *bool `json:"fieldTimeInCurrentStatus,omitempty"`
+	// The focus view grouping.
+	FocusViewGrouping *string `json:"focusViewGrouping,omitempty"`
+	// The focus view ordering.
+	FocusViewOrdering *string `json:"focusViewOrdering,omitempty"`
+	// The focus view ordering direction.
+	FocusViewOrderingDirection *string `json:"focusViewOrderingDirection,omitempty"`
 	// List of column model IDs which should be hidden on a board.
 	HiddenColumns []string `json:"hiddenColumns,omitempty"`
 	// List of row model IDs which should be hidden on a board.
@@ -18827,8 +19180,12 @@ type ViewPreferencesValues struct {
 	ReleasePipelineFieldLatestRelease *bool `json:"releasePipelineFieldLatestRelease,omitempty"`
 	// Whether to show the releases field for release pipelines.
 	ReleasePipelineFieldReleases *bool `json:"releasePipelineFieldReleases,omitempty"`
+	// Whether to show the teams field for release pipelines.
+	ReleasePipelineFieldTeams *bool `json:"releasePipelineFieldTeams,omitempty"`
 	// Whether to show the type field for release pipelines.
 	ReleasePipelineFieldType *bool `json:"releasePipelineFieldType,omitempty"`
+	// The release pipeline grouping.
+	ReleasePipelineGrouping *string `json:"releasePipelineGrouping,omitempty"`
 	// The release pipelines view ordering.
 	ReleasePipelinesViewOrdering *string `json:"releasePipelinesViewOrdering,omitempty"`
 	// Whether to show the review avatar field.
@@ -18845,10 +19202,16 @@ type ViewPreferencesValues struct {
 	ReviewGrouping *string `json:"reviewGrouping,omitempty"`
 	// The review view ordering.
 	ReviewViewOrdering *string `json:"reviewViewOrdering,omitempty"`
+	// Whether to show the completion field for scheduled pipeline releases.
+	ScheduledPipelineReleaseFieldCompletion *bool `json:"scheduledPipelineReleaseFieldCompletion,omitempty"`
+	// Whether to show the description field for scheduled pipeline releases.
+	ScheduledPipelineReleaseFieldDescription *bool `json:"scheduledPipelineReleaseFieldDescription,omitempty"`
 	// Whether to show the release date field for scheduled pipeline releases.
 	ScheduledPipelineReleaseFieldReleaseDate *bool `json:"scheduledPipelineReleaseFieldReleaseDate,omitempty"`
-	// Whether to show the stage field for scheduled pipeline releases.
-	ScheduledPipelineReleaseFieldStage *bool `json:"scheduledPipelineReleaseFieldStage,omitempty"`
+	// Whether to show the version field for scheduled pipeline releases.
+	ScheduledPipelineReleaseFieldVersion *bool `json:"scheduledPipelineReleaseFieldVersion,omitempty"`
+	// The scheduled pipeline releases view grouping.
+	ScheduledPipelineReleasesViewGrouping *string `json:"scheduledPipelineReleasesViewGrouping,omitempty"`
 	// The scheduled pipeline releases view ordering.
 	ScheduledPipelineReleasesViewOrdering *string `json:"scheduledPipelineReleasesViewOrdering,omitempty"`
 	// The search result type filter.
@@ -19285,6 +19648,8 @@ type WorkflowDefinition struct {
 	Name string `json:"name"`
 	// The contextual project view associated with the workflow.
 	Project *Project `json:"project,omitempty"`
+	// The workflow definition's unique URL slug.
+	SlugID string `json:"slugId"`
 	// The sort order of the workflow definition within its siblings.
 	SortOrder string `json:"sortOrder"`
 	// The team associated with the workflow. If not set, the workflow is associated with the entire organization.
@@ -20009,6 +20374,126 @@ func (e AiConversationEntityListWidgetArgsEntitiesType) MarshalJSON() ([]byte, e
 	return buf.Bytes(), nil
 }
 
+// The initial source of an AI conversation.
+type AiConversationInitialSource string
+
+const (
+	AiConversationInitialSourceComment            AiConversationInitialSource = "comment"
+	AiConversationInitialSourceDirectChat         AiConversationInitialSource = "directChat"
+	AiConversationInitialSourceMicrosoftTeams     AiConversationInitialSource = "microsoftTeams"
+	AiConversationInitialSourcePullRequestComment AiConversationInitialSource = "pullRequestComment"
+	AiConversationInitialSourceSlack              AiConversationInitialSource = "slack"
+	AiConversationInitialSourceWorkflow           AiConversationInitialSource = "workflow"
+)
+
+var AllAiConversationInitialSource = []AiConversationInitialSource{
+	AiConversationInitialSourceComment,
+	AiConversationInitialSourceDirectChat,
+	AiConversationInitialSourceMicrosoftTeams,
+	AiConversationInitialSourcePullRequestComment,
+	AiConversationInitialSourceSlack,
+	AiConversationInitialSourceWorkflow,
+}
+
+func (e AiConversationInitialSource) IsValid() bool {
+	switch e {
+	case AiConversationInitialSourceComment, AiConversationInitialSourceDirectChat, AiConversationInitialSourceMicrosoftTeams, AiConversationInitialSourcePullRequestComment, AiConversationInitialSourceSlack, AiConversationInitialSourceWorkflow:
+		return true
+	}
+	return false
+}
+
+func (e AiConversationInitialSource) String() string {
+	return string(e)
+}
+
+func (e *AiConversationInitialSource) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = AiConversationInitialSource(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid AiConversationInitialSource", str)
+	}
+	return nil
+}
+
+func (e AiConversationInitialSource) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *AiConversationInitialSource) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e AiConversationInitialSource) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
+// The phase during which a conversation part was generated.
+type AiConversationPartPhase string
+
+const (
+	AiConversationPartPhaseAnswer     AiConversationPartPhase = "answer"
+	AiConversationPartPhaseCommentary AiConversationPartPhase = "commentary"
+)
+
+var AllAiConversationPartPhase = []AiConversationPartPhase{
+	AiConversationPartPhaseAnswer,
+	AiConversationPartPhaseCommentary,
+}
+
+func (e AiConversationPartPhase) IsValid() bool {
+	switch e {
+	case AiConversationPartPhaseAnswer, AiConversationPartPhaseCommentary:
+		return true
+	}
+	return false
+}
+
+func (e AiConversationPartPhase) String() string {
+	return string(e)
+}
+
+func (e *AiConversationPartPhase) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = AiConversationPartPhase(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid AiConversationPartPhase", str)
+	}
+	return nil
+}
+
+func (e AiConversationPartPhase) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *AiConversationPartPhase) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e AiConversationPartPhase) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
 // The type of a part in an AI conversation.
 type AiConversationPartType string
 
@@ -20261,6 +20746,7 @@ const (
 	AiConversationToolQueryUpdates                         AiConversationTool = "QueryUpdates"
 	AiConversationToolQueryView                            AiConversationTool = "QueryView"
 	AiConversationToolResearch                             AiConversationTool = "Research"
+	AiConversationToolRestoreEntity                        AiConversationTool = "RestoreEntity"
 	AiConversationToolRetrieveEntities                     AiConversationTool = "RetrieveEntities"
 	AiConversationToolSearchDocumentation                  AiConversationTool = "SearchDocumentation"
 	AiConversationToolSearchEntities                       AiConversationTool = "SearchEntities"
@@ -20284,6 +20770,7 @@ var AllAiConversationTool = []AiConversationTool{
 	AiConversationToolQueryUpdates,
 	AiConversationToolQueryView,
 	AiConversationToolResearch,
+	AiConversationToolRestoreEntity,
 	AiConversationToolRetrieveEntities,
 	AiConversationToolSearchDocumentation,
 	AiConversationToolSearchEntities,
@@ -20296,7 +20783,7 @@ var AllAiConversationTool = []AiConversationTool{
 
 func (e AiConversationTool) IsValid() bool {
 	switch e {
-	case AiConversationToolCodeIntelligence, AiConversationToolCreateEntity, AiConversationToolDeleteEntity, AiConversationToolGetMicrosoftTeamsConversationHistory, AiConversationToolGetPullRequestDiff, AiConversationToolGetPullRequestFile, AiConversationToolGetSlackConversationHistory, AiConversationToolInvokeMcpTool, AiConversationToolQueryActivity, AiConversationToolQueryUpdates, AiConversationToolQueryView, AiConversationToolResearch, AiConversationToolRetrieveEntities, AiConversationToolSearchDocumentation, AiConversationToolSearchEntities, AiConversationToolSuggestValues, AiConversationToolTranscribeMedia, AiConversationToolTranscribeVideo, AiConversationToolUpdateEntity, AiConversationToolWebSearch:
+	case AiConversationToolCodeIntelligence, AiConversationToolCreateEntity, AiConversationToolDeleteEntity, AiConversationToolGetMicrosoftTeamsConversationHistory, AiConversationToolGetPullRequestDiff, AiConversationToolGetPullRequestFile, AiConversationToolGetSlackConversationHistory, AiConversationToolInvokeMcpTool, AiConversationToolQueryActivity, AiConversationToolQueryUpdates, AiConversationToolQueryView, AiConversationToolResearch, AiConversationToolRestoreEntity, AiConversationToolRetrieveEntities, AiConversationToolSearchDocumentation, AiConversationToolSearchEntities, AiConversationToolSuggestValues, AiConversationToolTranscribeMedia, AiConversationToolTranscribeVideo, AiConversationToolUpdateEntity, AiConversationToolWebSearch:
 		return true
 	}
 	return false
@@ -20388,6 +20875,146 @@ func (e *AiConversationWidgetName) UnmarshalJSON(b []byte) error {
 }
 
 func (e AiConversationWidgetName) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
+// [Internal] The status of a prompt workflow.
+type AiPromptProgressStatus string
+
+const (
+	AiPromptProgressStatusCanceled   AiPromptProgressStatus = "canceled"
+	AiPromptProgressStatusCreated    AiPromptProgressStatus = "created"
+	AiPromptProgressStatusFailed     AiPromptProgressStatus = "failed"
+	AiPromptProgressStatusFinished   AiPromptProgressStatus = "finished"
+	AiPromptProgressStatusInProgress AiPromptProgressStatus = "inProgress"
+)
+
+var AllAiPromptProgressStatus = []AiPromptProgressStatus{
+	AiPromptProgressStatusCanceled,
+	AiPromptProgressStatusCreated,
+	AiPromptProgressStatusFailed,
+	AiPromptProgressStatusFinished,
+	AiPromptProgressStatusInProgress,
+}
+
+func (e AiPromptProgressStatus) IsValid() bool {
+	switch e {
+	case AiPromptProgressStatusCanceled, AiPromptProgressStatusCreated, AiPromptProgressStatusFailed, AiPromptProgressStatusFinished, AiPromptProgressStatusInProgress:
+		return true
+	}
+	return false
+}
+
+func (e AiPromptProgressStatus) String() string {
+	return string(e)
+}
+
+func (e *AiPromptProgressStatus) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = AiPromptProgressStatus(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid AiPromptProgressStatus", str)
+	}
+	return nil
+}
+
+func (e AiPromptProgressStatus) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *AiPromptProgressStatus) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e AiPromptProgressStatus) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
+// The type of AI prompt workflow.
+type AiPromptType string
+
+const (
+	AiPromptTypeAgentGuidance             AiPromptType = "agentGuidance"
+	AiPromptTypeAiConversation            AiPromptType = "aiConversation"
+	AiPromptTypeCodeIntelligence          AiPromptType = "codeIntelligence"
+	AiPromptTypeGongIssueIntake           AiPromptType = "gongIssueIntake"
+	AiPromptTypeInitiativeUpdates         AiPromptType = "initiativeUpdates"
+	AiPromptTypeIntercomIssueIntake       AiPromptType = "intercomIssueIntake"
+	AiPromptTypeInternalResearch          AiPromptType = "internalResearch"
+	AiPromptTypeMicrosoftTeamsIssueIntake AiPromptType = "microsoftTeamsIssueIntake"
+	AiPromptTypeProductIntelligence       AiPromptType = "productIntelligence"
+	AiPromptTypeProjectUpdates            AiPromptType = "projectUpdates"
+	AiPromptTypeSlackIssueIntake          AiPromptType = "slackIssueIntake"
+	AiPromptTypeTriageAgent               AiPromptType = "triageAgent"
+	AiPromptTypeZendeskIssueIntake        AiPromptType = "zendeskIssueIntake"
+)
+
+var AllAiPromptType = []AiPromptType{
+	AiPromptTypeAgentGuidance,
+	AiPromptTypeAiConversation,
+	AiPromptTypeCodeIntelligence,
+	AiPromptTypeGongIssueIntake,
+	AiPromptTypeInitiativeUpdates,
+	AiPromptTypeIntercomIssueIntake,
+	AiPromptTypeInternalResearch,
+	AiPromptTypeMicrosoftTeamsIssueIntake,
+	AiPromptTypeProductIntelligence,
+	AiPromptTypeProjectUpdates,
+	AiPromptTypeSlackIssueIntake,
+	AiPromptTypeTriageAgent,
+	AiPromptTypeZendeskIssueIntake,
+}
+
+func (e AiPromptType) IsValid() bool {
+	switch e {
+	case AiPromptTypeAgentGuidance, AiPromptTypeAiConversation, AiPromptTypeCodeIntelligence, AiPromptTypeGongIssueIntake, AiPromptTypeInitiativeUpdates, AiPromptTypeIntercomIssueIntake, AiPromptTypeInternalResearch, AiPromptTypeMicrosoftTeamsIssueIntake, AiPromptTypeProductIntelligence, AiPromptTypeProjectUpdates, AiPromptTypeSlackIssueIntake, AiPromptTypeTriageAgent, AiPromptTypeZendeskIssueIntake:
+		return true
+	}
+	return false
+}
+
+func (e AiPromptType) String() string {
+	return string(e)
+}
+
+func (e *AiPromptType) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = AiPromptType(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid AiPromptType", str)
+	}
+	return nil
+}
+
+func (e AiPromptType) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *AiPromptType) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e AiPromptType) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
 	e.MarshalGQL(&buf)
 	return buf.Bytes(), nil
@@ -21761,6 +22388,64 @@ func (e IssueSharedAccessDisallowedField) MarshalJSON() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// Policy controlling whether and by whom issues in a team can be shared with non-team-members.
+type IssueSharingPolicy string
+
+const (
+	IssueSharingPolicyAdminsOnly IssueSharingPolicy = "adminsOnly"
+	IssueSharingPolicyAllMembers IssueSharingPolicy = "allMembers"
+	IssueSharingPolicyDisabled   IssueSharingPolicy = "disabled"
+)
+
+var AllIssueSharingPolicy = []IssueSharingPolicy{
+	IssueSharingPolicyAdminsOnly,
+	IssueSharingPolicyAllMembers,
+	IssueSharingPolicyDisabled,
+}
+
+func (e IssueSharingPolicy) IsValid() bool {
+	switch e {
+	case IssueSharingPolicyAdminsOnly, IssueSharingPolicyAllMembers, IssueSharingPolicyDisabled:
+		return true
+	}
+	return false
+}
+
+func (e IssueSharingPolicy) String() string {
+	return string(e)
+}
+
+func (e *IssueSharingPolicy) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = IssueSharingPolicy(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid IssueSharingPolicy", str)
+	}
+	return nil
+}
+
+func (e IssueSharingPolicy) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *IssueSharingPolicy) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e IssueSharingPolicy) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
 type IssueSuggestionState string
 
 const (
@@ -23009,6 +23694,66 @@ func (e ProjectUpdateReminderFrequency) MarshalJSON() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// [ALPHA] How a pull request check should be opened in the client.
+type PullRequestCheckPresentation string
+
+const (
+	PullRequestCheckPresentationExternalOnly PullRequestCheckPresentation = "externalOnly"
+	PullRequestCheckPresentationJobLogs      PullRequestCheckPresentation = "jobLogs"
+	PullRequestCheckPresentationMarkdown     PullRequestCheckPresentation = "markdown"
+	PullRequestCheckPresentationRunLogs      PullRequestCheckPresentation = "runLogs"
+)
+
+var AllPullRequestCheckPresentation = []PullRequestCheckPresentation{
+	PullRequestCheckPresentationExternalOnly,
+	PullRequestCheckPresentationJobLogs,
+	PullRequestCheckPresentationMarkdown,
+	PullRequestCheckPresentationRunLogs,
+}
+
+func (e PullRequestCheckPresentation) IsValid() bool {
+	switch e {
+	case PullRequestCheckPresentationExternalOnly, PullRequestCheckPresentationJobLogs, PullRequestCheckPresentationMarkdown, PullRequestCheckPresentationRunLogs:
+		return true
+	}
+	return false
+}
+
+func (e PullRequestCheckPresentation) String() string {
+	return string(e)
+}
+
+func (e *PullRequestCheckPresentation) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = PullRequestCheckPresentation(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid PullRequestCheckPresentation", str)
+	}
+	return nil
+}
+
+func (e PullRequestCheckPresentation) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *PullRequestCheckPresentation) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e PullRequestCheckPresentation) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
 // The method used to merge a pull request.
 type PullRequestMergeMethod string
 
@@ -24066,6 +24811,7 @@ func (e UserContextViewType) MarshalJSON() ([]byte, error) {
 type UserFlagType string
 
 const (
+	UserFlagTypeAgentExamplesDismissed                   UserFlagType = "agentExamplesDismissed"
 	UserFlagTypeAll                                      UserFlagType = "all"
 	UserFlagTypeAnalyticsWelcomeDismissed                UserFlagType = "analyticsWelcomeDismissed"
 	UserFlagTypeCanPlaySnake                             UserFlagType = "canPlaySnake"
@@ -24109,6 +24855,8 @@ const (
 	UserFlagTypeTeamsPageIntroductionDismissed           UserFlagType = "teamsPageIntroductionDismissed"
 	UserFlagTypeThreadedCommentsNudgeIsSeen              UserFlagType = "threadedCommentsNudgeIsSeen"
 	UserFlagTypeTriageWelcomeDismissed                   UserFlagType = "triageWelcomeDismissed"
+	UserFlagTypeTryCodexDismissed                        UserFlagType = "tryCodexDismissed"
+	UserFlagTypeTryCursorDismissed                       UserFlagType = "tryCursorDismissed"
 	UserFlagTypeTryCyclesDismissed                       UserFlagType = "tryCyclesDismissed"
 	UserFlagTypeTryGithubDismissed                       UserFlagType = "tryGithubDismissed"
 	UserFlagTypeTryInvitePeopleDismissed                 UserFlagType = "tryInvitePeopleDismissed"
@@ -24118,6 +24866,7 @@ const (
 )
 
 var AllUserFlagType = []UserFlagType{
+	UserFlagTypeAgentExamplesDismissed,
 	UserFlagTypeAll,
 	UserFlagTypeAnalyticsWelcomeDismissed,
 	UserFlagTypeCanPlaySnake,
@@ -24161,6 +24910,8 @@ var AllUserFlagType = []UserFlagType{
 	UserFlagTypeTeamsPageIntroductionDismissed,
 	UserFlagTypeThreadedCommentsNudgeIsSeen,
 	UserFlagTypeTriageWelcomeDismissed,
+	UserFlagTypeTryCodexDismissed,
+	UserFlagTypeTryCursorDismissed,
 	UserFlagTypeTryCyclesDismissed,
 	UserFlagTypeTryGithubDismissed,
 	UserFlagTypeTryInvitePeopleDismissed,
@@ -24171,7 +24922,7 @@ var AllUserFlagType = []UserFlagType{
 
 func (e UserFlagType) IsValid() bool {
 	switch e {
-	case UserFlagTypeAll, UserFlagTypeAnalyticsWelcomeDismissed, UserFlagTypeCanPlaySnake, UserFlagTypeCanPlayTetris, UserFlagTypeCommandMenuClearShortcutTip, UserFlagTypeCompletedOnboarding, UserFlagTypeCycleWelcomeDismissed, UserFlagTypeDesktopDownloadToastDismissed, UserFlagTypeDesktopInstalled, UserFlagTypeDesktopTabsOnboardingDismissed, UserFlagTypeDueDateShortcutMigration, UserFlagTypeEditorSlashCommandUsed, UserFlagTypeEmptyActiveIssuesDismissed, UserFlagTypeEmptyBacklogDismissed, UserFlagTypeEmptyCustomViewsDismissed, UserFlagTypeEmptyMyIssuesDismissed, UserFlagTypeEmptyParagraphSlashCommandTip, UserFlagTypeFigmaPluginBannerDismissed, UserFlagTypeFigmaPromptDismissed, UserFlagTypeHelpIslandFeatureInsightsDismissed, UserFlagTypeImportBannerDismissed, UserFlagTypeInitiativesBannerDismissed, UserFlagTypeInsightsHelpDismissed, UserFlagTypeInsightsWelcomeDismissed, UserFlagTypeIssueLabelSuggestionUsed, UserFlagTypeIssueMovePromptCompleted, UserFlagTypeJoinTeamIntroductionDismissed, UserFlagTypeListSelectionTip, UserFlagTypeMigrateThemePreference, UserFlagTypeMilestoneOnboardingIsSeenAndDismissed, UserFlagTypeProjectBacklogWelcomeDismissed, UserFlagTypeProjectBoardOnboardingIsSeenAndDismissed, UserFlagTypeProjectUpdatesWelcomeDismissed, UserFlagTypeProjectWelcomeDismissed, UserFlagTypePulseWelcomeDismissed, UserFlagTypeRewindBannerDismissed, UserFlagTypeSlackAgentPromoFromCreateNewIssueShown, UserFlagTypeSlackBotWelcomeMessageShown, UserFlagTypeSlackCommentReactionTipShown, UserFlagTypeTeamsBotWelcomeMessageShown, UserFlagTypeTeamsPageIntroductionDismissed, UserFlagTypeThreadedCommentsNudgeIsSeen, UserFlagTypeTriageWelcomeDismissed, UserFlagTypeTryCyclesDismissed, UserFlagTypeTryGithubDismissed, UserFlagTypeTryInvitePeopleDismissed, UserFlagTypeTryRoadmapsDismissed, UserFlagTypeTryTriageDismissed, UserFlagTypeUpdatedSlackThreadSyncIntegration:
+	case UserFlagTypeAgentExamplesDismissed, UserFlagTypeAll, UserFlagTypeAnalyticsWelcomeDismissed, UserFlagTypeCanPlaySnake, UserFlagTypeCanPlayTetris, UserFlagTypeCommandMenuClearShortcutTip, UserFlagTypeCompletedOnboarding, UserFlagTypeCycleWelcomeDismissed, UserFlagTypeDesktopDownloadToastDismissed, UserFlagTypeDesktopInstalled, UserFlagTypeDesktopTabsOnboardingDismissed, UserFlagTypeDueDateShortcutMigration, UserFlagTypeEditorSlashCommandUsed, UserFlagTypeEmptyActiveIssuesDismissed, UserFlagTypeEmptyBacklogDismissed, UserFlagTypeEmptyCustomViewsDismissed, UserFlagTypeEmptyMyIssuesDismissed, UserFlagTypeEmptyParagraphSlashCommandTip, UserFlagTypeFigmaPluginBannerDismissed, UserFlagTypeFigmaPromptDismissed, UserFlagTypeHelpIslandFeatureInsightsDismissed, UserFlagTypeImportBannerDismissed, UserFlagTypeInitiativesBannerDismissed, UserFlagTypeInsightsHelpDismissed, UserFlagTypeInsightsWelcomeDismissed, UserFlagTypeIssueLabelSuggestionUsed, UserFlagTypeIssueMovePromptCompleted, UserFlagTypeJoinTeamIntroductionDismissed, UserFlagTypeListSelectionTip, UserFlagTypeMigrateThemePreference, UserFlagTypeMilestoneOnboardingIsSeenAndDismissed, UserFlagTypeProjectBacklogWelcomeDismissed, UserFlagTypeProjectBoardOnboardingIsSeenAndDismissed, UserFlagTypeProjectUpdatesWelcomeDismissed, UserFlagTypeProjectWelcomeDismissed, UserFlagTypePulseWelcomeDismissed, UserFlagTypeRewindBannerDismissed, UserFlagTypeSlackAgentPromoFromCreateNewIssueShown, UserFlagTypeSlackBotWelcomeMessageShown, UserFlagTypeSlackCommentReactionTipShown, UserFlagTypeTeamsBotWelcomeMessageShown, UserFlagTypeTeamsPageIntroductionDismissed, UserFlagTypeThreadedCommentsNudgeIsSeen, UserFlagTypeTriageWelcomeDismissed, UserFlagTypeTryCodexDismissed, UserFlagTypeTryCursorDismissed, UserFlagTypeTryCyclesDismissed, UserFlagTypeTryGithubDismissed, UserFlagTypeTryInvitePeopleDismissed, UserFlagTypeTryRoadmapsDismissed, UserFlagTypeTryTriageDismissed, UserFlagTypeUpdatedSlackThreadSyncIntegration:
 		return true
 	}
 	return false
@@ -24592,6 +25343,7 @@ const (
 	ViewTypeFeedCreated                      ViewType = "feedCreated"
 	ViewTypeFeedFollowing                    ViewType = "feedFollowing"
 	ViewTypeFeedPopular                      ViewType = "feedPopular"
+	ViewTypeFocus                            ViewType = "focus"
 	ViewTypeInbox                            ViewType = "inbox"
 	ViewTypeInitiative                       ViewType = "initiative"
 	ViewTypeInitiativeOverview               ViewType = "initiativeOverview"
@@ -24656,6 +25408,7 @@ var AllViewType = []ViewType{
 	ViewTypeFeedCreated,
 	ViewTypeFeedFollowing,
 	ViewTypeFeedPopular,
+	ViewTypeFocus,
 	ViewTypeInbox,
 	ViewTypeInitiative,
 	ViewTypeInitiativeOverview,
@@ -24701,7 +25454,7 @@ var AllViewType = []ViewType{
 
 func (e ViewType) IsValid() bool {
 	switch e {
-	case ViewTypeActiveIssues, ViewTypeAgents, ViewTypeAllIssues, ViewTypeArchive, ViewTypeBacklog, ViewTypeBoard, ViewTypeCompletedCycle, ViewTypeContinuousPipelineReleases, ViewTypeCreatedReviews, ViewTypeCustomView, ViewTypeCustomViews, ViewTypeCustomer, ViewTypeCustomers, ViewTypeCycle, ViewTypeDashboards, ViewTypeEmbeddedCustomerNeeds, ViewTypeFeedAll, ViewTypeFeedCreated, ViewTypeFeedFollowing, ViewTypeFeedPopular, ViewTypeInbox, ViewTypeInitiative, ViewTypeInitiativeOverview, ViewTypeInitiativeOverviewSubInitiatives, ViewTypeInitiatives, ViewTypeInitiativesCompleted, ViewTypeInitiativesPlanned, ViewTypeIssueIdentifiers, ViewTypeLabel, ViewTypeMyIssues, ViewTypeMyIssuesActivity, ViewTypeMyIssuesCreatedByMe, ViewTypeMyIssuesSharedWithMe, ViewTypeMyIssuesSubscribedTo, ViewTypeMyReviews, ViewTypeProject, ViewTypeProjectCustomerNeeds, ViewTypeProjectDocuments, ViewTypeProjectLabel, ViewTypeProjects, ViewTypeProjectsAll, ViewTypeProjectsBacklog, ViewTypeProjectsClosed, ViewTypeQuickView, ViewTypeRelease, ViewTypeReleasePipelines, ViewTypeReviews, ViewTypeRoadmap, ViewTypeRoadmapAll, ViewTypeRoadmapBacklog, ViewTypeRoadmapClosed, ViewTypeRoadmaps, ViewTypeScheduledPipelineReleases, ViewTypeSearch, ViewTypeSplitSearch, ViewTypeSubIssues, ViewTypeTeams, ViewTypeTriage, ViewTypeUserProfile, ViewTypeUserProfileCreatedByUser, ViewTypeWorkspaceMembers:
+	case ViewTypeActiveIssues, ViewTypeAgents, ViewTypeAllIssues, ViewTypeArchive, ViewTypeBacklog, ViewTypeBoard, ViewTypeCompletedCycle, ViewTypeContinuousPipelineReleases, ViewTypeCreatedReviews, ViewTypeCustomView, ViewTypeCustomViews, ViewTypeCustomer, ViewTypeCustomers, ViewTypeCycle, ViewTypeDashboards, ViewTypeEmbeddedCustomerNeeds, ViewTypeFeedAll, ViewTypeFeedCreated, ViewTypeFeedFollowing, ViewTypeFeedPopular, ViewTypeFocus, ViewTypeInbox, ViewTypeInitiative, ViewTypeInitiativeOverview, ViewTypeInitiativeOverviewSubInitiatives, ViewTypeInitiatives, ViewTypeInitiativesCompleted, ViewTypeInitiativesPlanned, ViewTypeIssueIdentifiers, ViewTypeLabel, ViewTypeMyIssues, ViewTypeMyIssuesActivity, ViewTypeMyIssuesCreatedByMe, ViewTypeMyIssuesSharedWithMe, ViewTypeMyIssuesSubscribedTo, ViewTypeMyReviews, ViewTypeProject, ViewTypeProjectCustomerNeeds, ViewTypeProjectDocuments, ViewTypeProjectLabel, ViewTypeProjects, ViewTypeProjectsAll, ViewTypeProjectsBacklog, ViewTypeProjectsClosed, ViewTypeQuickView, ViewTypeRelease, ViewTypeReleasePipelines, ViewTypeReviews, ViewTypeRoadmap, ViewTypeRoadmapAll, ViewTypeRoadmapBacklog, ViewTypeRoadmapClosed, ViewTypeRoadmaps, ViewTypeScheduledPipelineReleases, ViewTypeSearch, ViewTypeSplitSearch, ViewTypeSubIssues, ViewTypeTeams, ViewTypeTriage, ViewTypeUserProfile, ViewTypeUserProfileCreatedByUser, ViewTypeWorkspaceMembers:
 		return true
 	}
 	return false
@@ -24861,22 +25614,24 @@ func (e WorkflowTriggerType) MarshalJSON() ([]byte, error) {
 type WorkflowType string
 
 const (
-	WorkflowTypeCustom           WorkflowType = "custom"
+	WorkflowTypeAutomation       WorkflowType = "automation"
 	WorkflowTypeSLA              WorkflowType = "sla"
 	WorkflowTypeTriage           WorkflowType = "triage"
+	WorkflowTypeTriageAutomation WorkflowType = "triageAutomation"
 	WorkflowTypeViewSubscription WorkflowType = "viewSubscription"
 )
 
 var AllWorkflowType = []WorkflowType{
-	WorkflowTypeCustom,
+	WorkflowTypeAutomation,
 	WorkflowTypeSLA,
 	WorkflowTypeTriage,
+	WorkflowTypeTriageAutomation,
 	WorkflowTypeViewSubscription,
 }
 
 func (e WorkflowType) IsValid() bool {
 	switch e {
-	case WorkflowTypeCustom, WorkflowTypeSLA, WorkflowTypeTriage, WorkflowTypeViewSubscription:
+	case WorkflowTypeAutomation, WorkflowTypeSLA, WorkflowTypeTriage, WorkflowTypeTriageAutomation, WorkflowTypeViewSubscription:
 		return true
 	}
 	return false

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,6 +1,7 @@
 schema {
   query: Query
   mutation: Mutation
+  subscription: Subscription
 }
 
 "Indicates exactly one field must be supplied and this field must not be `null`."
@@ -1075,6 +1076,10 @@ type AiConversation implements Node {
   """
   id: ID!
   """
+  The initial source of the conversation.
+  """
+  initialSource: AiConversationInitialSource!
+  """
   The iteration ID of the conversation in agentic workflow.
   """
   iterationId: String
@@ -1454,6 +1459,18 @@ type AiConversationGetSlackConversationHistoryToolCall implements AiConversation
   rawResult: JSON
 }
 
+"""
+The initial source of an AI conversation.
+"""
+enum AiConversationInitialSource {
+  comment
+  directChat
+  microsoftTeams
+  pullRequestComment
+  slack
+  workflow
+}
+
 type AiConversationInvokeMcpToolToolCall implements AiConversationBaseToolCall {
   """
   The arguments to the tool call.
@@ -1505,6 +1522,10 @@ Metadata about a part in an AI conversation.
 """
 type AiConversationPartMetadata {
   """
+  The ended timestamp of the part.
+  """
+  endedAt: String
+  """
   The eval log ID of the part.
   """
   evalLogId: String
@@ -1513,9 +1534,25 @@ type AiConversationPartMetadata {
   """
   feedback: JSONObject
   """
+  The phase during which the part was generated.
+  """
+  phase: AiConversationPartPhase
+  """
+  The started timestamp of the part.
+  """
+  startedAt: String
+  """
   The turn ID of the part.
   """
   turnId: String!
+}
+
+"""
+The phase during which a conversation part was generated.
+"""
+enum AiConversationPartPhase {
+  answer
+  commentary
 }
 
 """
@@ -1715,6 +1752,30 @@ type AiConversationResearchToolCallResult {
   progressId: String
 }
 
+type AiConversationRestoreEntityToolCall implements AiConversationBaseToolCall {
+  """
+  The arguments to the tool call.
+  """
+  args: AiConversationRestoreEntityToolCallArgs
+  displayInfo: AiConversationToolDisplayInfo!
+  """
+  The name of the tool that was called.
+  """
+  name: AiConversationTool!
+  """
+  The arguments of the tool call.
+  """
+  rawArgs: JSON
+  """
+  The result of the tool call.
+  """
+  rawResult: JSON
+}
+
+type AiConversationRestoreEntityToolCallArgs {
+  entity: AiConversationSearchEntitiesToolCallResultEntities!
+}
+
 type AiConversationRetrieveEntitiesToolCall implements AiConversationBaseToolCall {
   """
   The arguments to the tool call.
@@ -1871,6 +1932,7 @@ enum AiConversationTool {
   QueryUpdates
   QueryView
   Research
+  RestoreEntity
   RetrieveEntities
   SearchDocumentation
   SearchEntities
@@ -1897,6 +1959,7 @@ union AiConversationToolCall =
   | AiConversationQueryUpdatesToolCall
   | AiConversationQueryViewToolCall
   | AiConversationResearchToolCall
+  | AiConversationRestoreEntityToolCall
   | AiConversationRetrieveEntitiesToolCall
   | AiConversationSearchDocumentationToolCall
   | AiConversationSearchEntitiesToolCall
@@ -1989,7 +2052,8 @@ type AiConversationUpdateEntityToolCall implements AiConversationBaseToolCall {
 }
 
 type AiConversationUpdateEntityToolCallArgs {
-  entity: AiConversationSearchEntitiesToolCallResultEntities!
+  entities: [AiConversationSearchEntitiesToolCallResultEntities!]
+  entity: AiConversationSearchEntitiesToolCallResultEntities
 }
 
 type AiConversationWebSearchToolCall implements AiConversationBaseToolCall {
@@ -2064,6 +2128,156 @@ type AiConversationWidgetPart implements AiConversationBasePart {
 }
 
 """
+[Internal] A prompt workflow progress.
+"""
+type AiPromptProgress implements Node {
+  """
+  The time at which the entity was archived. Null if the entity has not been archived.
+  """
+  archivedAt: DateTime
+  """
+  The time at which the entity was created.
+  """
+  createdAt: DateTime!
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  """
+  [Internal] The log ID for the prompt workflow, if available.
+  """
+  logId: String
+  """
+  [Internal] The metadata for the prompt workflow.
+  """
+  metadata: JSONObject!
+  """
+  [Internal] The status of the prompt workflow.
+  """
+  status: AiPromptProgressStatus!
+  """
+  [Internal] The type of AI prompt workflow.
+  """
+  type: AiPromptType!
+  """
+  The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
+      been updated after creation.
+  """
+  updatedAt: DateTime!
+}
+
+type AiPromptProgressConnection {
+  edges: [AiPromptProgressEdge!]!
+  nodes: [AiPromptProgress!]!
+  pageInfo: PageInfo!
+}
+
+type AiPromptProgressEdge {
+  """
+  Used in `before` and `after` args
+  """
+  cursor: String!
+  node: AiPromptProgress!
+}
+
+"""
+[Internal] AI prompt progress filtering options.
+"""
+input AiPromptProgressFilter {
+  """
+  [Internal] Compound filters, all of which need to be matched by the AI prompt progress.
+  """
+  and: [AiPromptProgressFilter!]
+  """
+  Comparator for the created at date.
+  """
+  createdAt: DateComparator
+  """
+  Comparator for the identifier.
+  """
+  id: IDComparator
+  """
+  [Internal] Compound filters, one of which need to be matched by the AI prompt progress.
+  """
+  or: [AiPromptProgressFilter!]
+  """
+  [Internal] Comparator for the AI prompt workflow status.
+  """
+  status: AiPromptProgressStatusComparator
+  """
+  [Internal] Comparator for the AI prompt workflow type.
+  """
+  type: AiPromptTypeComparator
+  """
+  Comparator for the updated at date.
+  """
+  updatedAt: DateComparator
+}
+
+"""
+[Internal] The status of a prompt workflow.
+"""
+enum AiPromptProgressStatus {
+  canceled
+  created
+  failed
+  finished
+  inProgress
+}
+
+"""
+[Internal] Comparator for the AI prompt workflow status.
+"""
+input AiPromptProgressStatusComparator {
+  """
+  Equals constraint.
+  """
+  eq: AiPromptProgressStatus
+  """
+  In-array constraint.
+  """
+  in: [AiPromptProgressStatus!]
+  """
+  Not-equals constraint.
+  """
+  neq: AiPromptProgressStatus
+  """
+  Not-in-array constraint.
+  """
+  nin: [AiPromptProgressStatus!]
+  """
+  Null constraint. Matches any non-null values if the given value is false, otherwise it matches null values.
+  """
+  null: Boolean
+}
+
+"""
+[Internal] Filter for AI prompt progress subscription events.
+"""
+input AiPromptProgressSubscriptionFilter {
+  """
+  [Internal] Filter by comment ID.
+  """
+  commentId: IDComparator
+  """
+  [Internal] Filter by issue ID.
+  """
+  issueId: IDComparator
+  """
+  [Internal] Filter by pull request comment ID.
+  """
+  pullRequestCommentId: IDComparator
+  """
+  [Internal] Filter by prompt workflow status.
+  """
+  status: AiPromptProgressStatusComparator
+  """
+  [Internal] Filter by prompt workflow type.
+  """
+  type: AiPromptTypeComparator
+}
+
+"""
 AI prompt rules for a team.
 """
 type AiPromptRules implements Node {
@@ -2088,6 +2302,51 @@ type AiPromptRules implements Node {
   The user who last updated the AI prompt rules.
   """
   updatedBy: User
+}
+
+"""
+The type of AI prompt workflow.
+"""
+enum AiPromptType {
+  agentGuidance
+  aiConversation
+  codeIntelligence
+  gongIssueIntake
+  initiativeUpdates
+  intercomIssueIntake
+  internalResearch
+  microsoftTeamsIssueIntake
+  productIntelligence
+  projectUpdates
+  slackIssueIntake
+  triageAgent
+  zendeskIssueIntake
+}
+
+"""
+[Internal] Comparator for the AI prompt workflow type.
+"""
+input AiPromptTypeComparator {
+  """
+  Equals constraint.
+  """
+  eq: AiPromptType
+  """
+  In-array constraint.
+  """
+  in: [AiPromptType!]
+  """
+  Not-equals constraint.
+  """
+  neq: AiPromptType
+  """
+  Not-in-array constraint.
+  """
+  nin: [AiPromptType!]
+  """
+  Null constraint. Matches any non-null values if the given value is false, otherwise it matches null values.
+  """
+  null: Boolean
 }
 
 input AirbyteConfigurationInput {
@@ -2887,11 +3146,15 @@ type AuthOrganization {
   """
   Allowed authentication providers, empty array means all are allowed
   """
-  allowedAuthServices: [String!]!
+  allowedAuthServices: [String!]! @deprecated(reason: "Use authSettings.allowedAuthServices instead.")
   """
   An approximate count of users, updated once per day.
   """
   approximateUserCount: Float!
+  """
+  Authentication settings for the organization.
+  """
+  authSettings: JSONObject!
   """
   The time at which the entity was created.
   """
@@ -3235,13 +3498,17 @@ type CodingAgentSandboxPayload {
   """
   startedAt: DateTime
   """
+  Temporal URL to view all workflows for this sandbox.
+  """
+  temporalWorkflowUrl: String
+  """
   Claude Agent SDK conversation ID.
   """
   workerConversationId: String
 }
 
 """
-A comment associated with an issue.
+A comment associated with an entity.
 """
 type Comment implements Node {
   """
@@ -3277,6 +3544,39 @@ type Comment implements Node {
     """
     orderBy: PaginationOrderBy
   ): AgentSessionConnection!
+  """
+  [Internal] AI prompt progresses associated with this comment.
+  """
+  aiPromptProgresses(
+    """
+    A cursor to be used with first for forward pagination
+    """
+    after: String
+    """
+    A cursor to be used with last for backward pagination.
+    """
+    before: String
+    """
+    Filter returned AI prompt progresses.
+    """
+    filter: AiPromptProgressFilter
+    """
+    The number of items to forward paginate (used with after). Defaults to 50.
+    """
+    first: Int
+    """
+    Should archived resources be included (default: false)
+    """
+    includeArchived: Boolean
+    """
+    The number of items to backward paginate (used with before). Defaults to 50.
+    """
+    last: Int
+    """
+    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+    """
+    orderBy: PaginationOrderBy
+  ): AiPromptProgressConnection!
   """
   The time at which the entity was archived. Null if the entity has not been archived.
   """
@@ -3392,6 +3692,14 @@ type Comment implements Node {
   """
   id: ID!
   """
+  [Internal] The initiative that the comment is associated with.
+  """
+  initiative: Initiative
+  """
+  [Internal] The ID of the initiative that the comment is associated with.
+  """
+  initiativeId: String
+  """
   The initiative update that the comment is associated with.
   """
   initiativeUpdate: InitiativeUpdate
@@ -3427,6 +3735,14 @@ type Comment implements Node {
   The post that the comment is associated with.
   """
   post: Post
+  """
+  [Internal] The project that the comment is associated with.
+  """
+  project: Project
+  """
+  [Internal] The ID of the project that the comment is associated with.
+  """
+  projectId: String
   """
   The project update that the comment is associated with.
   """
@@ -3532,6 +3848,10 @@ type CommentChildWebhookPayload {
   """
   id: String!
   """
+  [Internal] The ID of the initiative this comment belongs to.
+  """
+  initiativeId: String
+  """
   The ID of the initiative update this comment belongs to.
   """
   initiativeUpdateId: String
@@ -3539,6 +3859,10 @@ type CommentChildWebhookPayload {
   The ID of the issue this comment belongs to.
   """
   issueId: String
+  """
+  [Internal] The ID of the project this comment belongs to.
+  """
+  projectId: String
   """
   The ID of the project update this comment belongs to.
   """
@@ -3578,6 +3902,10 @@ input CommentCollectionFilter {
   """
   id: IDComparator
   """
+  [Internal] Filters that the comment's initiative must satisfy.
+  """
+  initiative: NullableInitiativeFilter
+  """
   Filters that the comment's issue must satisfy.
   """
   issue: NullableIssueFilter
@@ -3597,6 +3925,10 @@ input CommentCollectionFilter {
   Filters that the comment parent must satisfy.
   """
   parent: NullableCommentFilter
+  """
+  [Internal] Filters that the comment's project must satisfy.
+  """
+  project: NullableProjectFilter
   """
   Filters that the comment's project update must satisfy.
   """
@@ -3663,6 +3995,10 @@ input CommentCreateInput {
   """
   id: String
   """
+  [Internal] The initiative to associate the comment with.
+  """
+  initiativeId: String
+  """
   The initiative update to associate the comment with.
   """
   initiativeUpdateId: String
@@ -3678,6 +4014,10 @@ input CommentCreateInput {
   The post to associate the comment with.
   """
   postId: String
+  """
+  [Internal] The project to associate the comment with.
+  """
+  projectId: String
   """
   The project update to associate the comment with.
   """
@@ -3725,6 +4065,10 @@ input CommentFilter {
   """
   id: IDComparator
   """
+  [Internal] Filters that the comment's initiative must satisfy.
+  """
+  initiative: NullableInitiativeFilter
+  """
   Filters that the comment's issue must satisfy.
   """
   issue: NullableIssueFilter
@@ -3740,6 +4084,10 @@ input CommentFilter {
   Filters that the comment parent must satisfy.
   """
   parent: NullableCommentFilter
+  """
+  [Internal] Filters that the comment's project must satisfy.
+  """
+  project: NullableProjectFilter
   """
   Filters that the comment's project update must satisfy.
   """
@@ -3849,6 +4197,10 @@ type CommentWebhookPayload {
   """
   id: String!
   """
+  [Internal] The ID of the initiative this comment belongs to.
+  """
+  initiativeId: String
+  """
   The initiative update this comment belongs to.
   """
   initiativeUpdate: InitiativeUpdateChildWebhookPayload
@@ -3876,6 +4228,10 @@ type CommentWebhookPayload {
   The ID of the post this comment belongs to.
   """
   postId: String
+  """
+  [Internal] The ID of the project this comment belongs to.
+  """
+  projectId: String
   """
   The project update this comment belongs to.
   """
@@ -7475,6 +7831,10 @@ type Document implements Node {
   """
   sortOrder: Float!
   """
+  [Internal] A one-sentence AI-generated summary of the document content.
+  """
+  summary: String
+  """
   [Internal] The team that the document is associated with.
   """
   team: Team
@@ -7636,6 +7996,37 @@ type DocumentContentChildWebhookPayload {
   project: ProjectChildWebhookPayload
 }
 
+"""
+A draft revision of document content, pending user review.
+"""
+type DocumentContentDraft implements Node {
+  """
+  The time at which the entity was archived. Null if the entity has not been archived.
+  """
+  archivedAt: DateTime
+  """
+  The draft content state as a base64 encoded Yjs state update.
+  """
+  contentState: String!
+  """
+  The time at which the entity was created.
+  """
+  createdAt: DateTime!
+  documentContent: DocumentContent!
+  documentContentId: String!
+  """
+  The unique identifier of the entity.
+  """
+  id: ID!
+  """
+  The last time at which the entity was meaningfully updated. This is the same as the creation time if the entity hasn't
+      been updated after creation.
+  """
+  updatedAt: DateTime!
+  user: User!
+  userId: String!
+}
+
 type DocumentContentHistoryPayload {
   """
   The document content history entries.
@@ -7762,6 +8153,10 @@ input DocumentFilter {
   """
   creator: UserFilter
   """
+  Filters that the document's cycle must satisfy.
+  """
+  cycle: CycleFilter
+  """
   Comparator for the identifier.
   """
   id: IDComparator
@@ -7781,6 +8176,10 @@ input DocumentFilter {
   Filters that the document's project must satisfy.
   """
   project: ProjectFilter
+  """
+  Filters that the document's release must satisfy.
+  """
+  release: ReleaseFilter
   """
   Comparator for the document slug ID.
   """
@@ -8067,6 +8466,10 @@ type DocumentSearchResult implements Node {
   """
   sortOrder: Float!
   """
+  [Internal] A one-sentence AI-generated summary of the document content.
+  """
+  summary: String
+  """
   [Internal] The team that the document is associated with.
   """
   team: Team
@@ -8287,7 +8690,7 @@ type Draft implements Node {
   """
   id: ID!
   """
-  The initiative for which this is a draft initiative update.
+  The initiative for which this is a draft comment or initiative update.
   """
   initiative: Initiative
   """
@@ -8311,7 +8714,7 @@ type Draft implements Node {
   """
   post: Post
   """
-  The project for which this is a draft project update.
+  The project for which this is a draft comment or project update.
   """
   project: Project
   """
@@ -8675,6 +9078,10 @@ input EmailUserAccountAuthChallengeInput {
   Whether to only return the login code. This is used by mobile apps to skip showing the login link.
   """
   loginCodeOnly: Boolean
+  """
+  PostHog session ID for attribution tracking.
+  """
+  sessionId: String
 }
 
 type EmailUserAccountAuthChallengeResponse {
@@ -10154,6 +10561,10 @@ input GitHubRepoInput {
   """
   archived: Boolean
   """
+  The external identifier (GitHub node ID) for the repository.
+  """
+  externalId: String
+  """
   The full name of the repository.
   """
   fullName: String!
@@ -10199,6 +10610,10 @@ input GitHubSettingsInput {
   The enterprise URL if this is a GitHub Enterprise Cloud integration.
   """
   enterpriseUrl: String
+  """
+  The stable external identifier (GitHub node ID) for the organization.
+  """
+  externalOrgId: String
   """
   The avatar URL for the GitHub organization.
   """
@@ -10394,6 +10809,10 @@ input GoogleUserAccountAuthInput {
   The URI to redirect the user to.
   """
   redirectUri: String
+  """
+  PostHog session ID for attribution tracking.
+  """
+  sessionId: String
   """
   The timezone of the user's browser.
   """
@@ -17214,6 +17633,15 @@ enum IssueSharedAccessDisallowedField {
 }
 
 """
+Policy controlling whether and by whom issues in a team can be shared with non-team-members.
+"""
+enum IssueSharingPolicy {
+  adminsOnly
+  allMembers
+  disabled
+}
+
+"""
 Payload for issue SLA webhook events.
 """
 type IssueSlaWebhookPayload {
@@ -17450,6 +17878,28 @@ type IssueStatusChangedNotificationWebhookPayload {
   The ID of the user who received the notification.
   """
   userId: String!
+}
+
+"""
+Filter for issue subscription events.
+"""
+input IssueSubscriptionFilter {
+  """
+  Filter by assignee ID.
+  """
+  assigneeId: IDComparator
+  """
+  Filter by project ID.
+  """
+  projectId: IDComparator
+  """
+  Filter by workflow state ID.
+  """
+  stateId: IDComparator
+  """
+  Filter by team ID.
+  """
+  teamId: IDComparator
 }
 
 type IssueSuggestion implements Node {
@@ -18281,6 +18731,10 @@ input JiraLinearMappingInput {
   The Jira id for this project.
   """
   jiraProjectId: String!
+  """
+  Whether this mapping uses legacy unidirectional sync behavior where no changes sync from Linear to Jira.
+  """
+  legacyUnidirectional: Boolean
   """
   The Linear team id to map to the given project.
   """
@@ -19274,6 +19728,10 @@ type Mutation {
   Updates a customer need
   """
   customerNeedUpdate(
+    """
+    Whether to remove any existing attachment associated with the customer need.
+    """
+    clearAttachment: Boolean
     """
     The identifier of the customer need to update.
     """
@@ -21508,6 +21966,23 @@ type Mutation {
     slackChannelName: String
   ): ProjectPayload!
   """
+  [Internal] Creates a Slack channel for an existing project.
+  """
+  projectCreateSlackChannel(
+    """
+    The identifier of the project.
+    """
+    id: String!
+    """
+    The identifier of the Slack integration to use. When not provided, uses the organization's configured integration.
+    """
+    integrationId: String
+    """
+    The full name for the Slack channel to create (including prefix). When provided, a Slack channel will be created and connected to the project.
+    """
+    slackChannelName: String!
+  ): ProjectPayload!
+  """
   Deletes (trashes) a project.
   """
   projectDelete(
@@ -22364,7 +22839,7 @@ type Mutation {
     input: TriageResponsibilityUpdateInput!
   ): TriageResponsibilityPayload!
   """
-  [Internal] Updates existing Slack integration scopes.
+  [Internal] Updates existing Slack and Asks integration scopes.
   """
   updateIntegrationSlackScopes(
     """
@@ -23437,6 +23912,10 @@ input NullableCommentFilter {
   """
   id: IDComparator
   """
+  [Internal] Filters that the comment's initiative must satisfy.
+  """
+  initiative: NullableInitiativeFilter
+  """
   Filters that the comment's issue must satisfy.
   """
   issue: NullableIssueFilter
@@ -23456,6 +23935,10 @@ input NullableCommentFilter {
   Filters that the comment parent must satisfy.
   """
   parent: NullableCommentFilter
+  """
+  [Internal] Filters that the comment's project must satisfy.
+  """
+  project: NullableProjectFilter
   """
   Filters that the comment's project update must satisfy.
   """
@@ -23754,6 +24237,92 @@ input NullableDurationComparator {
   Null constraint. Matches any non-null values if the given value is false, otherwise it matches null values.
   """
   null: Boolean
+}
+
+"""
+Initiative filtering options.
+"""
+input NullableInitiativeFilter {
+  """
+  Comparator for the initiative activity type.
+  """
+  activityType: StringComparator
+  """
+  Filters that the initiative must be an ancestor of.
+  """
+  ancestors: InitiativeCollectionFilter
+  """
+  Compound filters, all of which need to be matched by the initiative.
+  """
+  and: [NullableInitiativeFilter!]
+  """
+  Comparator for the initiative completed at date.
+  """
+  completedAt: NullableDateComparator
+  """
+  Comparator for the created at date.
+  """
+  createdAt: DateComparator
+  """
+  Filters that the initiative creator must satisfy.
+  """
+  creator: NullableUserFilter
+  """
+  Comparator for the initiative health: onTrack, atRisk, offTrack
+  """
+  health: StringComparator
+  """
+  Comparator for the initiative health (with age): onTrack, atRisk, offTrack, outdated, noUpdate
+  """
+  healthWithAge: StringComparator
+  """
+  Comparator for the identifier.
+  """
+  id: IDComparator
+  """
+  Filters that the initiative updates must satisfy.
+  """
+  initiativeUpdates: InitiativeUpdatesCollectionFilter
+  """
+  Comparator for the initiative name.
+  """
+  name: StringComparator
+  """
+  Filter based on the existence of the relation.
+  """
+  null: Boolean
+  """
+  Compound filters, one of which need to be matched by the initiative.
+  """
+  or: [NullableInitiativeFilter!]
+  """
+  Filters that the initiative owner must satisfy.
+  """
+  owner: NullableUserFilter
+  """
+  Comparator for the initiative slug ID.
+  """
+  slugId: StringComparator
+  """
+  Comparator for the initiative started at date.
+  """
+  startedAt: NullableDateComparator
+  """
+  Comparator for the initiative status: Planned, Active, Completed
+  """
+  status: StringComparator
+  """
+  Comparator for the initiative target date.
+  """
+  targetDate: NullableDateComparator
+  """
+  Filters that the initiative teams must satisfy.
+  """
+  teams: TeamCollectionFilter
+  """
+  Comparator for the updated at date.
+  """
+  updatedAt: DateComparator
 }
 
 """
@@ -24975,6 +25544,10 @@ An organization. Organizations are root-level objects that contain user accounts
 """
 type Organization implements Node {
   """
+  [INTERNAL] Whether the organization has enabled agent automation.
+  """
+  agentAutomationEnabled: Boolean!
+  """
   [INTERNAL] Whether the organization has enabled the AI add-on (which at this point only includes triage suggestions).
   """
   aiAddonEnabled: Boolean!
@@ -25001,7 +25574,7 @@ type Organization implements Node {
   """
   Allowed authentication providers, empty array means all are allowed.
   """
-  allowedAuthServices: [String!]!
+  allowedAuthServices: [String!]! @deprecated(reason: "Use authSettings.allowedAuthServices instead.")
   """
   Allowed file upload content types
   """
@@ -25011,6 +25584,10 @@ type Organization implements Node {
   """
   archivedAt: DateTime
   """
+  Authentication settings for the organization.
+  """
+  authSettings: JSONObject!
+  """
   [INTERNAL] Whether code intelligence is enabled for the organization.
   """
   codeIntelligenceEnabled: Boolean!
@@ -25018,6 +25595,10 @@ type Organization implements Node {
   [INTERNAL] GitHub repository in owner/repo format for code intelligence.
   """
   codeIntelligenceRepository: String
+  """
+  [INTERNAL] Whether the organization has enabled the Coding Agent.
+  """
+  codingAgentEnabled: Boolean!
   """
   The time at which the entity was created.
   """
@@ -25081,7 +25662,7 @@ type Organization implements Node {
   """
   Whether to hide other organizations for new users signing up with email domains claimed by this organization.
   """
-  hideNonPrimaryOrganizations: Boolean!
+  hideNonPrimaryOrganizations: Boolean! @deprecated(reason: "Use authSettings.hideNonPrimaryOrganizations instead.")
   """
   Whether HIPAA compliance is enabled for organization.
   """
@@ -25172,6 +25753,10 @@ type Organization implements Node {
   [Internal] Whether the organization has enabled Linear Agent.
   """
   linearAgentEnabled: Boolean!
+  """
+  [Internal] Settings for Linear Agent features.
+  """
+  linearAgentSettings: JSONObject!
   """
   The organization's logo URL.
   """
@@ -25433,6 +26018,25 @@ type OrganizationAcceptedOrExpiredInviteDetailsPayload {
   The status of the invite.
   """
   status: OrganizationInviteStatus!
+}
+
+input OrganizationAuthSettingsInput {
+  """
+  [Internal] The minimum role required for the auth service bypass exemption.
+  """
+  allowedAuthServiceBypassRole: String
+  """
+  Allowed authentication providers, empty array means all are allowed.
+  """
+  allowedAuthServices: [String!]
+  """
+  Whether to disable admin/owner auth service bypass.
+  """
+  disableAuthServiceBypass: Boolean
+  """
+  Whether to hide non-primary organizations during signup for users with matching email domains.
+  """
+  hideNonPrimaryOrganizations: Boolean
 }
 
 type OrganizationCancelDeletePayload {
@@ -25821,6 +26425,28 @@ input OrganizationIpRestrictionInput {
   type: String!
 }
 
+input OrganizationLinearAgentMcpServerAllowlistEntryInput {
+  """
+  [Internal] The MCP server URL that Linear Agent is allowed to use.
+  """
+  url: String!
+}
+
+input OrganizationLinearAgentSettingsInput {
+  """
+  [Internal] The MCP server allowlist for Linear Agent. When unset, all MCP servers are allowed.
+  """
+  mcpServersAllowlist: [OrganizationLinearAgentMcpServerAllowlistEntryInput!]
+  """
+  [Internal] Whether the organization has enabled MCP servers for Linear Agent.
+  """
+  mcpServersEnabled: Boolean
+  """
+  [Internal] Whether the organization has enabled web search for Linear Agent.
+  """
+  webSearchEnabled: Boolean
+}
+
 type OrganizationMeta {
   """
   Allowed authentication providers, empty array means all are allowed.
@@ -25912,6 +26538,10 @@ type OrganizationStartTrialPayload {
 
 input OrganizationUpdateInput {
   """
+  [INTERNAL] Whether the organization has enabled agent automation.
+  """
+  agentAutomationEnabled: Boolean
+  """
   [INTERNAL] Whether the organization has enabled the AI add-on.
   """
   aiAddonEnabled: Boolean
@@ -25940,6 +26570,10 @@ input OrganizationUpdateInput {
   """
   allowedFileUploadContentTypes: [String!]
   """
+  The authentication settings for the organization.
+  """
+  authSettings: OrganizationAuthSettingsInput
+  """
   [INTERNAL] Whether code intelligence is enabled for the organization.
   """
   codeIntelligenceEnabled: Boolean
@@ -25947,6 +26581,10 @@ input OrganizationUpdateInput {
   [INTERNAL] GitHub repository in owner/repo format for code intelligence.
   """
   codeIntelligenceRepository: String
+  """
+  [INTERNAL] Whether the organization has enabled the Coding Agent.
+  """
+  codingAgentEnabled: Boolean
   """
   [INTERNAL] Configuration settings for the Customers feature.
   """
@@ -26015,6 +26653,10 @@ input OrganizationUpdateInput {
   [Internal] Whether the organization has enabled Linear Agent.
   """
   linearAgentEnabled: Boolean
+  """
+  [Internal] Settings for Linear Agent features.
+  """
+  linearAgentSettings: OrganizationLinearAgentSettingsInput
   """
   The logo of the organization.
   """
@@ -31177,6 +31819,10 @@ type PullRequest implements Node {
   """
   archivedAt: DateTime
   """
+  The base SHA of the pull request.
+  """
+  baseSha: String
+  """
   [Internal] The checks associated with the pull request.
   """
   checks: [PullRequestCheck!]!
@@ -31192,6 +31838,10 @@ type PullRequest implements Node {
   [Internal] The user who created the pull request.
   """
   creator: User
+  """
+  The head SHA of the pull request.
+  """
+  headSha: String
   """
   The unique identifier of the entity.
   """
@@ -31256,6 +31906,10 @@ type PullRequestCheck {
   """
   name: String!
   """
+  How the check should be opened in the client.
+  """
+  presentation: PullRequestCheckPresentation
+  """
   The date/time at which when the check was started.
   """
   startedAt: DateTime
@@ -31271,6 +31925,16 @@ type PullRequestCheck {
   The name of the workflow that triggered the check.
   """
   workflowName: String
+}
+
+"""
+[ALPHA] How a pull request check should be opened in the client.
+"""
+enum PullRequestCheckPresentation {
+  externalOnly
+  jobLogs
+  markdown
+  runLogs
 }
 
 """
@@ -33298,6 +33962,10 @@ type Query {
     """
     before: String
     """
+    Filter returned release pipelines.
+    """
+    filter: ReleasePipelineFilter
+    """
     The number of items to forward paginate (used with after). Defaults to 50.
     """
     first: Int
@@ -33343,6 +34011,10 @@ type Query {
     A cursor to be used with last for backward pagination.
     """
     before: String
+    """
+    Filter returned release stages.
+    """
+    filter: ReleaseStageFilter
     """
     The number of items to forward paginate (used with after). Defaults to 50.
     """
@@ -34326,6 +34998,48 @@ type Release implements Node {
   """
   id: ID!
   """
+  [ALPHA] Number of issues associated with the release.
+  """
+  issueCount(
+    """
+    Include archived issues in the count.
+    """
+    includeArchived: Boolean = false
+  ): Int!
+  """
+  [ALPHA] Issues associated with the release.
+  """
+  issues(
+    """
+    A cursor to be used with first for forward pagination
+    """
+    after: String
+    """
+    A cursor to be used with last for backward pagination.
+    """
+    before: String
+    """
+    Filter returned issues.
+    """
+    filter: IssueFilter
+    """
+    The number of items to forward paginate (used with after). Defaults to 50.
+    """
+    first: Int
+    """
+    Should archived resources be included (default: false)
+    """
+    includeArchived: Boolean
+    """
+    The number of items to backward paginate (used with before). Defaults to 50.
+    """
+    last: Int
+    """
+    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+    """
+    orderBy: PaginationOrderBy
+  ): IssueConnection!
+  """
   [Internal] Links associated with the release.
   """
   links(
@@ -34710,6 +35424,10 @@ type ReleasePipeline implements Node {
     By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
     """
     orderBy: PaginationOrderBy
+    """
+    [ALPHA] Sort returned releases.
+    """
+    sort: [ReleaseSortInput!]
   ): ReleaseConnection!
   """
   The pipeline's unique slug identifier.
@@ -34745,6 +35463,35 @@ type ReleasePipeline implements Node {
     orderBy: PaginationOrderBy
   ): ReleaseStageConnection!
   """
+  [ALPHA] Teams associated with this pipeline.
+  """
+  teams(
+    """
+    A cursor to be used with first for forward pagination
+    """
+    after: String
+    """
+    A cursor to be used with last for backward pagination.
+    """
+    before: String
+    """
+    The number of items to forward paginate (used with after). Defaults to 50.
+    """
+    first: Int
+    """
+    Should archived resources be included (default: false)
+    """
+    includeArchived: Boolean
+    """
+    The number of items to backward paginate (used with before). Defaults to 50.
+    """
+    last: Int
+    """
+    By which field should the pagination order by. Available options are createdAt (default) and updatedAt.
+    """
+    orderBy: PaginationOrderBy
+  ): TeamConnection!
+  """
   The type of the pipeline.
   """
   type: ReleasePipelineType!
@@ -34753,6 +35500,10 @@ type ReleasePipeline implements Node {
       been updated after creation.
   """
   updatedAt: DateTime!
+  """
+  [Internal] Release pipeline URL.
+  """
+  url: String!
 }
 
 """
@@ -34796,6 +35547,10 @@ input ReleasePipelineCreateInput {
   The pipeline's unique slug identifier. If not provided, it will be auto-generated.
   """
   slugId: String
+  """
+  The identifiers of the teams this pipeline is associated with.
+  """
+  teamIds: [String!]
   """
   The type of the pipeline.
   """
@@ -34877,9 +35632,23 @@ input ReleasePipelineUpdateInput {
   """
   slugId: String
   """
+  The identifiers of the teams this pipeline is associated with.
+  """
+  teamIds: [String!]
+  """
   The type of the pipeline.
   """
   type: ReleasePipelineType
+}
+
+"""
+Release sorting options.
+"""
+input ReleaseSortInput {
+  """
+  Sort by release stage
+  """
+  stage: ReleaseStageSort
 }
 
 """
@@ -35068,6 +35837,20 @@ type ReleaseStagePayload {
   Whether the operation was successful.
   """
   success: Boolean!
+}
+
+"""
+Release stage sorting options.
+"""
+input ReleaseStageSort {
+  """
+  Whether nulls should be sorted first or last
+  """
+  nulls: PaginationNulls = last
+  """
+  The order for the individual sort
+  """
+  order: PaginationSortOrder
 }
 
 """
@@ -36315,22 +37098,6 @@ Comparator for issue source type.
 """
 input SourceMetadataComparator {
   """
-  Equals constraint.
-  """
-  eq: String
-  """
-  In-array constraint.
-  """
-  in: [String!]
-  """
-  Not-equals constraint.
-  """
-  neq: String
-  """
-  Not-in-array constraint.
-  """
-  nin: [String!]
-  """
   Null constraint. Matches any non-null values if the given value is false, otherwise it matches null values.
   """
   null: Boolean
@@ -36621,6 +37388,301 @@ input SubTypeComparator {
   Null constraint. Matches any non-null values if the given value is false, otherwise it matches null values.
   """
   null: Boolean
+}
+
+type Subscription {
+  """
+  Triggered when an agent activity is created
+  """
+  agentActivityCreated: AgentActivity!
+  """
+  Triggered when an agent activity is updated
+  """
+  agentActivityUpdated: AgentActivity!
+  """
+  Triggered when an agent session is created
+  """
+  agentSessionCreated: AgentSession!
+  """
+  Triggered when an agent session is updated
+  """
+  agentSessionUpdated: AgentSession!
+  """
+  Triggered when an ai conversation is updated
+  """
+  aiConversationUpdated: AiConversation!
+  """
+  Triggered when an ai prompt progress is created
+  """
+  aiPromptProgressCreated(filter: AiPromptProgressSubscriptionFilter): AiPromptProgress!
+  """
+  Triggered when an ai prompt progress is updated
+  """
+  aiPromptProgressUpdated(filter: AiPromptProgressSubscriptionFilter): AiPromptProgress!
+  """
+  Triggered when a comment is archived
+  """
+  commentArchived: Comment!
+  """
+  Triggered when a comment is created
+  """
+  commentCreated: Comment!
+  """
+  Triggered when a comment is deleted
+  """
+  commentDeleted: Comment!
+  """
+  Triggered when a a comment is unarchived
+  """
+  commentUnarchived: Comment!
+  """
+  Triggered when a comment is updated
+  """
+  commentUpdated: Comment!
+  """
+  Triggered when a cycle is archived
+  """
+  cycleArchived: Cycle!
+  """
+  Triggered when a cycle is created
+  """
+  cycleCreated: Cycle!
+  """
+  Triggered when a cycle is updated
+  """
+  cycleUpdated: Cycle!
+  """
+  Triggered when a document is archived
+  """
+  documentArchived: Document!
+  """
+  Triggered when a document content draft is created
+  """
+  documentContentDraftCreated: DocumentContentDraft!
+  """
+  Triggered when a document content draft is deleted
+  """
+  documentContentDraftDeleted: DocumentContentDraft!
+  """
+  Triggered when a document content draft is updated
+  """
+  documentContentDraftUpdated: DocumentContentDraft!
+  """
+  Triggered when a document is created
+  """
+  documentCreated: Document!
+  """
+  Triggered when a a document is unarchived
+  """
+  documentUnarchived: Document!
+  """
+  Triggered when a document is updated
+  """
+  documentUpdated: Document!
+  """
+  Triggered when a draft is created
+  """
+  draftCreated: Draft!
+  """
+  Triggered when a draft is deleted
+  """
+  draftDeleted: Draft!
+  """
+  Triggered when a draft is updated
+  """
+  draftUpdated: Draft!
+  """
+  Triggered when a favorite is created
+  """
+  favoriteCreated: Favorite!
+  """
+  Triggered when a favorite is deleted
+  """
+  favoriteDeleted: Favorite!
+  """
+  Triggered when a favorite is updated
+  """
+  favoriteUpdated: Favorite!
+  """
+  Triggered when an initiative is created
+  """
+  initiativeCreated: Initiative!
+  """
+  Triggered when an initiative is deleted
+  """
+  initiativeDeleted: Initiative!
+  """
+  Triggered when an initiative is updated
+  """
+  initiativeUpdated: Initiative!
+  """
+  Triggered when an issue is archived
+  """
+  issueArchived: Issue!
+  """
+  Triggered when an issue is created
+  """
+  issueCreated(filter: IssueSubscriptionFilter): Issue!
+  """
+  Triggered when an issue draft is created
+  """
+  issueDraftCreated: IssueDraft!
+  """
+  Triggered when an issue draft is deleted
+  """
+  issueDraftDeleted: IssueDraft!
+  """
+  Triggered when an issue draft is updated
+  """
+  issueDraftUpdated: IssueDraft!
+  """
+  Triggered when an issue history is created
+  """
+  issueHistoryCreated: IssueHistory!
+  """
+  Triggered when an issue history is updated
+  """
+  issueHistoryUpdated: IssueHistory!
+  """
+  Triggered when an issue label is created
+  """
+  issueLabelCreated: IssueLabel!
+  """
+  Triggered when an issue label is deleted
+  """
+  issueLabelDeleted: IssueLabel!
+  """
+  Triggered when an issue label is updated
+  """
+  issueLabelUpdated: IssueLabel!
+  """
+  Triggered when an issue relation is created
+  """
+  issueRelationCreated: IssueRelation!
+  """
+  Triggered when an issue relation is deleted
+  """
+  issueRelationDeleted: IssueRelation!
+  """
+  Triggered when an issue relation is updated
+  """
+  issueRelationUpdated: IssueRelation!
+  """
+  Triggered when a an issue is unarchived
+  """
+  issueUnarchived: Issue!
+  """
+  Triggered when an issue is updated
+  """
+  issueUpdated(filter: IssueSubscriptionFilter): Issue!
+  """
+  Triggered when a notification is archived
+  """
+  notificationArchived: Notification!
+  """
+  Triggered when a notification is created
+  """
+  notificationCreated: Notification!
+  """
+  Triggered when a notification is deleted
+  """
+  notificationDeleted: Notification!
+  """
+  Triggered when a a notification is unarchived
+  """
+  notificationUnarchived: Notification!
+  """
+  Triggered when a notification is updated
+  """
+  notificationUpdated: Notification!
+  """
+  Triggered when an organization is updated
+  """
+  organizationUpdated: Organization!
+  """
+  Triggered when a project is archived
+  """
+  projectArchived: Project!
+  """
+  Triggered when a project is created
+  """
+  projectCreated: Project!
+  """
+  Triggered when a a project is unarchived
+  """
+  projectUnarchived: Project!
+  """
+  Triggered when a project update is created
+  """
+  projectUpdateCreated: ProjectUpdate!
+  """
+  Triggered when a project update is deleted
+  """
+  projectUpdateDeleted: ProjectUpdate!
+  """
+  Triggered when a project update is updated
+  """
+  projectUpdateUpdated: ProjectUpdate!
+  """
+  Triggered when a project is updated
+  """
+  projectUpdated: Project!
+  """
+  Triggered when a roadmap is created
+  """
+  roadmapCreated: Roadmap!
+  """
+  Triggered when a roadmap is deleted
+  """
+  roadmapDeleted: Roadmap!
+  """
+  Triggered when a roadmap is updated
+  """
+  roadmapUpdated: Roadmap!
+  """
+  Triggered when a team is created
+  """
+  teamCreated: Team!
+  """
+  Triggered when a team is deleted
+  """
+  teamDeleted: Team!
+  """
+  Triggered when a team membership is created
+  """
+  teamMembershipCreated: TeamMembership!
+  """
+  Triggered when a team membership is deleted
+  """
+  teamMembershipDeleted: TeamMembership!
+  """
+  Triggered when a team membership is updated
+  """
+  teamMembershipUpdated: TeamMembership!
+  """
+  Triggered when a team is updated
+  """
+  teamUpdated: Team!
+  """
+  Triggered when an user is created
+  """
+  userCreated: User!
+  """
+  Triggered when an user is updated
+  """
+  userUpdated: User!
+  """
+  Triggered when a workflow state is archived
+  """
+  workflowStateArchived: WorkflowState!
+  """
+  Triggered when a workflow state is created
+  """
+  workflowStateCreated: WorkflowState!
+  """
+  Triggered when a workflow state is updated
+  """
+  workflowStateUpdated: WorkflowState!
 }
 
 type SuccessPayload {
@@ -37168,7 +38230,7 @@ type Team implements Node {
   """
   organization: Organization!
   """
-  [Internal] The team's parent team.
+  The team's parent team.
   """
   parent: Team
   """
@@ -37579,6 +38641,10 @@ input TeamCreateInput {
   The issue estimation type to use. Must be one of "notUsed", "exponential", "fibonacci", "linear", "tShirt".
   """
   issueEstimationType: String
+  """
+  The policy controlling whether and by whom issues in the team can be shared with non-team-members.
+  """
+  issueSharingPolicy: IssueSharingPolicy
   """
   The key of the team. If not given, the key will be generated based on the name of the team.
   """
@@ -38071,6 +39137,10 @@ input TeamUpdateInput {
   The issue estimation type to use. Must be one of "notUsed", "exponential", "fibonacci", "linear", "tShirt".
   """
   issueEstimationType: String
+  """
+  The policy controlling whether and by whom issues in the team can be shared with non-team-members.
+  """
+  issueSharingPolicy: IssueSharingPolicy
   """
   Whether new users should join this team by default. Mutation restricted to workspace admins or owners!
   """
@@ -39437,6 +40507,7 @@ input UserFilter {
 The types of flags that the user can have.
 """
 enum UserFlagType {
+  agentExamplesDismissed
   all
   analyticsWelcomeDismissed
   canPlaySnake
@@ -39480,6 +40551,8 @@ enum UserFlagType {
   teamsPageIntroductionDismissed
   threadedCommentsNudgeIsSeen
   triageWelcomeDismissed
+  tryCodexDismissed
+  tryCursorDismissed
   tryCyclesDismissed
   tryGithubDismissed
   tryInvitePeopleDismissed
@@ -40347,6 +41420,18 @@ type ViewPreferencesValues {
   """
   fieldTimeInCurrentStatus: Boolean
   """
+  The focus view grouping.
+  """
+  focusViewGrouping: String
+  """
+  The focus view ordering.
+  """
+  focusViewOrdering: String
+  """
+  The focus view ordering direction.
+  """
+  focusViewOrderingDirection: String
+  """
   List of column model IDs which should be hidden on a board.
   """
   hiddenColumns: [String!]
@@ -40699,9 +41784,17 @@ type ViewPreferencesValues {
   """
   releasePipelineFieldReleases: Boolean
   """
+  Whether to show the teams field for release pipelines.
+  """
+  releasePipelineFieldTeams: Boolean
+  """
   Whether to show the type field for release pipelines.
   """
   releasePipelineFieldType: Boolean
+  """
+  The release pipeline grouping.
+  """
+  releasePipelineGrouping: String
   """
   The release pipelines view ordering.
   """
@@ -40735,13 +41828,25 @@ type ViewPreferencesValues {
   """
   reviewViewOrdering: String
   """
+  Whether to show the completion field for scheduled pipeline releases.
+  """
+  scheduledPipelineReleaseFieldCompletion: Boolean
+  """
+  Whether to show the description field for scheduled pipeline releases.
+  """
+  scheduledPipelineReleaseFieldDescription: Boolean
+  """
   Whether to show the release date field for scheduled pipeline releases.
   """
   scheduledPipelineReleaseFieldReleaseDate: Boolean
   """
-  Whether to show the stage field for scheduled pipeline releases.
+  Whether to show the version field for scheduled pipeline releases.
   """
-  scheduledPipelineReleaseFieldStage: Boolean
+  scheduledPipelineReleaseFieldVersion: Boolean
+  """
+  The scheduled pipeline releases view grouping.
+  """
+  scheduledPipelineReleasesViewGrouping: String
   """
   The scheduled pipeline releases view ordering.
   """
@@ -40940,6 +42045,7 @@ enum ViewType {
   feedCreated
   feedFollowing
   feedPopular
+  focus
   inbox
   initiative
   initiativeOverview
@@ -41408,6 +42514,10 @@ type WorkflowDefinition implements Node {
   """
   project: Project
   """
+  The workflow definition's unique URL slug.
+  """
+  slugId: String!
+  """
   The sort order of the workflow definition within its siblings.
   """
   sortOrder: String!
@@ -41727,9 +42837,10 @@ enum WorkflowTriggerType {
 }
 
 enum WorkflowType {
-  custom
+  automation
   sla
   triage
+  triageAutomation
   viewSubscription
 }
 


### PR DESCRIPTION
## Summary
- Sync schema.graphql from @linear/sdk@80.0.0 (was 77.0.0)
- Regenerate `internal/graphql/models.go` with new types
- Notable public additions: GraphQL subscriptions, Team.parent, Release.issues, IssueSharingPolicy, PullRequest baseSha/headSha, DocumentFilter by cycle/release

Ref #45