### PR TITLE
ci: improve release workflow reliability

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,21 +82,24 @@ jobs:
             PRERELEASE="--prerelease"
           fi
 
-          # Idempotent: if the release already exists (e.g., from a partial run),
-          # upload assets to it instead of failing. See v2.2.0/v2.2.1 incident.
-          if gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
-            # --clobber overwrites existing assets on workflow re-run
-            gh release upload "$VERSION" \
-              --repo "$GITHUB_REPOSITORY" \
-              --clobber \
-              dist/go-linear-* \
-              dist/checksums.txt
-          else
+          # Create draft release if it doesn't already exist (idempotent for re-runs).
+          if ! gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
             gh release create "$VERSION" \
               --repo "$GITHUB_REPOSITORY" \
               --title "$VERSION" \
               --generate-notes \
-              ${PRERELEASE:+"$PRERELEASE"} \
-              dist/go-linear-* \
-              dist/checksums.txt
+              --draft \
+              ${PRERELEASE:+"$PRERELEASE"}
           fi
+
+          # Upload artifacts to the draft release (--clobber handles re-runs).
+          gh release upload "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber \
+            dist/go-linear-* \
+            dist/checksums.txt
+
+          # Publish the release.
+          gh release edit "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft=false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
                 -X github.com/chainguard-sandbox/go-linear/v2/pkg/linear.Version=${VERSION} \
                 -X github.com/chainguard-sandbox/go-linear/v2/pkg/linear.GitCommit=${GITHUB_SHA} \
                 -X github.com/chainguard-sandbox/go-linear/v2/pkg/linear.GitTreeState=clean \
-                -X github.com/chainguard-sandbox/go-linear/v2/pkg/linear.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                -X github.com/chainguard-sandbox/go-linear/v2/pkg/linear.BuildDate=$(date -u -d @$(git log -1 --pretty=%ct) +%Y-%m-%dT%H:%M:%SZ)" \
               -o "$output" \
               ./cmd/linear
           done
@@ -79,10 +79,18 @@ jobs:
             PRERELEASE="--prerelease"
           fi
 
-          gh release create "$VERSION" \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "$VERSION" \
-            --generate-notes \
-            $PRERELEASE \
-            dist/go-linear-* \
-            dist/checksums.txt
+          if gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            gh release upload "$VERSION" \
+              --repo "$GITHUB_REPOSITORY" \
+              --clobber \
+              dist/go-linear-* \
+              dist/checksums.txt
+          else
+            gh release create "$VERSION" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$VERSION" \
+              --generate-notes \
+              ${PRERELEASE:+"$PRERELEASE"} \
+              dist/go-linear-* \
+              dist/checksums.txt
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,9 @@ jobs:
 
           mkdir -p dist
 
+          # Cache commit timestamp for reproducible BuildDate (GNU date -d, Linux only)
+          BUILD_DATE=$(date -u -d @$(git log -1 --pretty=%ct) +%Y-%m-%dT%H:%M:%SZ)
+
           for platform in "${platforms[@]}"; do
             GOOS="${platform%/*}"
             GOARCH="${platform#*/}"
@@ -60,7 +63,7 @@ jobs:
                 -X github.com/chainguard-sandbox/go-linear/v2/pkg/linear.Version=${VERSION} \
                 -X github.com/chainguard-sandbox/go-linear/v2/pkg/linear.GitCommit=${GITHUB_SHA} \
                 -X github.com/chainguard-sandbox/go-linear/v2/pkg/linear.GitTreeState=clean \
-                -X github.com/chainguard-sandbox/go-linear/v2/pkg/linear.BuildDate=$(date -u -d @$(git log -1 --pretty=%ct) +%Y-%m-%dT%H:%M:%SZ)" \
+                -X github.com/chainguard-sandbox/go-linear/v2/pkg/linear.BuildDate=${BUILD_DATE}" \
               -o "$output" \
               ./cmd/linear
           done
@@ -79,7 +82,10 @@ jobs:
             PRERELEASE="--prerelease"
           fi
 
+          # Idempotent: if the release already exists (e.g., from a partial run),
+          # upload assets to it instead of failing. See v2.2.0/v2.2.1 incident.
           if gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            # --clobber overwrites existing assets on workflow re-run
             gh release upload "$VERSION" \
               --repo "$GITHUB_REPOSITORY" \
               --clobber \


### PR DESCRIPTION
## Summary
  - Use draft-then-publish release flow for immutable release compatibility                               
  - Use commit-anchored BuildDate via SOURCE_DATE_EPOCH for reproducible builds                           
  - Quote PRERELEASE variable properly (shellcheck SC2086)' 