### PR TITLE
feat(issue): add --team and structured filters to search command

### DIFF
--- a/cmd/linear/commands/issue/search.go
+++ b/cmd/linear/commands/issue/search.go
@@ -8,7 +8,9 @@ import (
 	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
 	"github.com/chainguard-sandbox/go-linear/v2/internal/config"
 	"github.com/chainguard-sandbox/go-linear/v2/internal/fieldfilter"
+	issuefilter "github.com/chainguard-sandbox/go-linear/v2/internal/filter/issue"
 	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/resolver"
 	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
 )
 
@@ -17,9 +19,11 @@ func NewSearchCommand(clientFactory cli.ClientFactory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search <query>",
 		Short: "Search issues by text query",
-		Long: `Search issues by text. Returns 8 default fields per result. Searches titles and descriptions. Use --count for totals.
+		Long: `Search issues by text with optional structured filters. Returns 8 default fields per result.
 
-Example: go-linear issue search "authentication bug" --limit=20
+Filters: --team (name/key), --assignee (name/email/'me'), --state, --priority (0-4), --label (repeatable)
+
+Example: go-linear issue search "authentication bug" --team=Engineering --limit=20
 
 Count: --count returns {"count": N} (see issue_list for details)
 Related: issue_list, issue_get`,
@@ -40,6 +44,13 @@ Related: issue_list, issue_get`,
 	cmd.Flags().BoolP("include-archived", "a", false, "Include archived issues")
 	cmd.Flags().Bool("count", false, "Return only count, not results (99% token reduction)")
 	cmd.Flags().String("fields", "", "defaults (id,identifier,title,url,state.name,team.key,priority,createdAt) | none | defaults,extra")
+
+	// Structured filters (same as issue list)
+	cmd.Flags().String("team", "", "Team name or key (e.g., 'Engineering', 'ENG')")
+	cmd.Flags().String("assignee", "", "Assignee name, email, or 'me'")
+	cmd.Flags().String("state", "", "State name (e.g., 'In Progress')")
+	cmd.Flags().Int("priority", -1, "Priority: 0=none, 1=urgent, 2=high, 3=normal, 4=low")
+	cmd.Flags().StringArray("label", []string{}, "Label names (repeatable)")
 
 	return cmd
 }
@@ -62,8 +73,16 @@ func runSearch(cmd *cobra.Command, client *linear.Client, query string) error {
 		includeArchivedPtr = &includeArchived
 	}
 
+	// Build filter from flags
+	res := resolver.New(client)
+	filterBuilder := issuefilter.NewIssueFilterBuilder(res)
+	if err := filterBuilder.FromFlags(ctx, cmd); err != nil {
+		return err
+	}
+	issueFilter := filterBuilder.Build()
+
 	// Search issues
-	searchResult, err := client.SearchIssues(ctx, query, &first, afterPtr, nil, includeArchivedPtr)
+	searchResult, err := client.SearchIssues(ctx, query, &first, afterPtr, issueFilter, includeArchivedPtr)
 	if err != nil {
 		return fmt.Errorf("failed to search issues: %w", err)
 	}

--- a/cmd/linear/commands/issue/search_test.go
+++ b/cmd/linear/commands/issue/search_test.go
@@ -22,7 +22,8 @@ func TestNewSearchCommand(t *testing.T) {
 	})
 
 	t.Run("flags exist", func(t *testing.T) {
-		expectedFlags := []string{"limit", "fields", "count", "include-archived"}
+		expectedFlags := []string{"limit", "fields", "count", "include-archived",
+			"team", "assignee", "state", "priority", "label"}
 		for _, flag := range expectedFlags {
 			if cmd.Flags().Lookup(flag) == nil {
 				t.Errorf("Expected flag %q not found", flag)
@@ -91,6 +92,94 @@ func TestRunSearch(t *testing.T) {
 		err := cmd.Execute()
 		if err != nil {
 			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+
+	t.Run("search with team filter", func(t *testing.T) {
+		cmd := NewSearchCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"test", "--team=ENG"})
+
+		err := cmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Errorf("Output should be valid JSON: %v", err)
+		}
+	})
+
+	t.Run("search with priority filter", func(t *testing.T) {
+		cmd := NewSearchCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"test", "--priority=2"})
+
+		err := cmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Errorf("Output should be valid JSON: %v", err)
+		}
+	})
+
+	t.Run("search with state filter", func(t *testing.T) {
+		cmd := NewSearchCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"test", "--state=In Progress"})
+
+		err := cmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Errorf("Output should be valid JSON: %v", err)
+		}
+	})
+
+	t.Run("search with multiple filters", func(t *testing.T) {
+		cmd := NewSearchCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"test", "--team=ENG", "--priority=1", "--state=Todo"})
+
+		err := cmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Errorf("Output should be valid JSON: %v", err)
+		}
+	})
+
+	t.Run("search with count and filter", func(t *testing.T) {
+		cmd := NewSearchCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"test", "--team=ENG", "--count"})
+
+		err := cmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Errorf("Output should be valid JSON: %v", err)
+		}
+		if _, ok := result["count"]; !ok {
+			t.Error("Expected 'count' field in output")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Adds `--team`, `--assignee`, `--state`, `--priority`, and `--label` flags to `issue search`
- Reuses existing `IssueFilterBuilder` from `issue list` — no new infrastructure needed
- Passes `IssueFilter` to `SearchIssues` GraphQL API (was previously always `nil`)

Closes #58

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./cmd/linear/commands/issue/` passes
- [ ] Manual: `go-linear issue search "bug" --team=ENG` scopes results to team

🤖 Generated with [Claude Code](https://claude.com/claude-code)