### PR TITLE
feat(issue): add subscribe and unsubscribe commands

### DIFF
--- a/cmd/linear/commands/issue/helpers_test.go
+++ b/cmd/linear/commands/issue/helpers_test.go
@@ -242,6 +242,22 @@ const (
 		}
 	}`
 
+	mockIssueSubscribeResponse = `{
+		"data": {
+			"issueSubscribe": {
+				"success": true
+			}
+		}
+	}`
+
+	mockIssueUnsubscribeResponse = `{
+		"data": {
+			"issueUnsubscribe": {
+				"success": true
+			}
+		}
+	}`
+
 	mockProjectsResponse = `{
 		"data": {
 			"projects": {
@@ -299,5 +315,7 @@ func defaultHandlers() map[string]string {
 		"IssueRelationCreate": mockIssueRelationCreateResponse,
 		"IssueRelationDelete": mockIssueRelationDeleteResponse,
 		"IssueRelationUpdate": mockIssueRelationUpdateResponse,
+		"IssueSubscribe":      mockIssueSubscribeResponse,
+		"IssueUnsubscribe":    mockIssueUnsubscribeResponse,
 	}
 }

--- a/cmd/linear/commands/issue/issue.go
+++ b/cmd/linear/commands/issue/issue.go
@@ -33,6 +33,8 @@ func NewIssueCommand(clientFactory cli.ClientFactory) *cobra.Command {
 	cmd.AddCommand(NewUnrelateCommand(clientFactory))
 	cmd.AddCommand(NewAddLabelCommand(clientFactory))
 	cmd.AddCommand(NewRemoveLabelCommand(clientFactory))
+	cmd.AddCommand(NewSubscribeCommand(clientFactory))
+	cmd.AddCommand(NewUnsubscribeCommand(clientFactory))
 
 	return cmd
 }

--- a/cmd/linear/commands/issue/subscribe.go
+++ b/cmd/linear/commands/issue/subscribe.go
@@ -1,0 +1,70 @@
+package issue
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/resolver"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewSubscribeCommand creates the issue subscribe command.
+func NewSubscribeCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "subscribe <id>",
+		Short: "Subscribe to issue notifications",
+		Long: `Subscribe to an issue to receive notifications on updates.
+
+Subscribes the current user by default. Use --user to subscribe another user.
+
+Example: go-linear issue subscribe ENG-123
+
+Related: issue_unsubscribe, notification_list`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runSubscribe(cmd, client, args[0])
+		},
+	}
+
+	cmd.Flags().String("user", "", "User to subscribe (name, email, or ID; default: current user)")
+	return cmd
+}
+
+func runSubscribe(cmd *cobra.Command, client *linear.Client, issueID string) error {
+	ctx := cmd.Context()
+	res := resolver.New(client)
+
+	resolvedIssueID, err := res.ResolveIssue(ctx, issueID)
+	if err != nil {
+		return fmt.Errorf("failed to resolve issue: %w", err)
+	}
+
+	var userIDPtr *string
+	userFlag, _ := cmd.Flags().GetString("user")
+	if userFlag != "" {
+		userID, err := res.ResolveUser(ctx, userFlag)
+		if err != nil {
+			return fmt.Errorf("failed to resolve user: %w", err)
+		}
+		userIDPtr = &userID
+	}
+
+	if err := client.IssueSubscribe(ctx, resolvedIssueID, userIDPtr); err != nil {
+		return fmt.Errorf("failed to subscribe to issue: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), map[string]any{
+		"success": true,
+		"issueId": issueID,
+		"action":  "subscribed",
+	}, true)
+}

--- a/cmd/linear/commands/issue/subscribe_test.go
+++ b/cmd/linear/commands/issue/subscribe_test.go
@@ -1,0 +1,135 @@
+package issue
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/testutil"
+)
+
+func TestNewSubscribeCommand(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+
+	factory := testutil.TestFactory(t, server.URL)
+	cmd := NewSubscribeCommand(factory)
+
+	t.Run("command setup", func(t *testing.T) {
+		if cmd.Use != "subscribe <id>" {
+			t.Errorf("Use = %q, want %q", cmd.Use, "subscribe <id>")
+		}
+	})
+
+	t.Run("flags exist", func(t *testing.T) {
+		if cmd.Flags().Lookup("user") == nil {
+			t.Error("Expected flag \"user\" not found")
+		}
+	})
+
+	t.Run("requires exactly one arg", func(t *testing.T) {
+		if err := cmd.Args(cmd, []string{}); err == nil {
+			t.Error("Expected error for no args")
+		}
+		if err := cmd.Args(cmd, []string{"ENG-123"}); err != nil {
+			t.Errorf("Unexpected error for one arg: %v", err)
+		}
+	})
+}
+
+func TestRunSubscribe(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+
+	factory := testutil.TestFactory(t, server.URL)
+
+	t.Run("subscribe to issue", func(t *testing.T) {
+		cmd := NewSubscribeCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"ENG-123"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("Output should be valid JSON: %v", err)
+		}
+		if result["success"] != true {
+			t.Error("Expected success: true")
+		}
+		if result["action"] != "subscribed" {
+			t.Errorf("Expected action \"subscribed\", got %q", result["action"])
+		}
+	})
+
+	t.Run("subscribe with user flag", func(t *testing.T) {
+		cmd := NewSubscribeCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"ENG-123", "--user=test@example.com"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("Output should be valid JSON: %v", err)
+		}
+		if result["success"] != true {
+			t.Error("Expected success: true")
+		}
+	})
+}
+
+func TestNewUnsubscribeCommand(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+
+	factory := testutil.TestFactory(t, server.URL)
+	cmd := NewUnsubscribeCommand(factory)
+
+	t.Run("command setup", func(t *testing.T) {
+		if cmd.Use != "unsubscribe <id>" {
+			t.Errorf("Use = %q, want %q", cmd.Use, "unsubscribe <id>")
+		}
+	})
+
+	t.Run("flags exist", func(t *testing.T) {
+		if cmd.Flags().Lookup("user") == nil {
+			t.Error("Expected flag \"user\" not found")
+		}
+	})
+}
+
+func TestRunUnsubscribe(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+
+	factory := testutil.TestFactory(t, server.URL)
+
+	t.Run("unsubscribe from issue", func(t *testing.T) {
+		cmd := NewUnsubscribeCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"ENG-123"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("Output should be valid JSON: %v", err)
+		}
+		if result["success"] != true {
+			t.Error("Expected success: true")
+		}
+		if result["action"] != "unsubscribed" {
+			t.Errorf("Expected action \"unsubscribed\", got %q", result["action"])
+		}
+	})
+}

--- a/cmd/linear/commands/issue/unsubscribe.go
+++ b/cmd/linear/commands/issue/unsubscribe.go
@@ -1,0 +1,70 @@
+package issue
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/resolver"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewUnsubscribeCommand creates the issue unsubscribe command.
+func NewUnsubscribeCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unsubscribe <id>",
+		Short: "Unsubscribe from issue notifications",
+		Long: `Unsubscribe from an issue to stop receiving notifications.
+
+Unsubscribes the current user by default. Use --user to unsubscribe another user.
+
+Example: go-linear issue unsubscribe ENG-123
+
+Related: issue_subscribe, notification_list`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runUnsubscribe(cmd, client, args[0])
+		},
+	}
+
+	cmd.Flags().String("user", "", "User to unsubscribe (name, email, or ID; default: current user)")
+	return cmd
+}
+
+func runUnsubscribe(cmd *cobra.Command, client *linear.Client, issueID string) error {
+	ctx := cmd.Context()
+	res := resolver.New(client)
+
+	resolvedIssueID, err := res.ResolveIssue(ctx, issueID)
+	if err != nil {
+		return fmt.Errorf("failed to resolve issue: %w", err)
+	}
+
+	var userIDPtr *string
+	userFlag, _ := cmd.Flags().GetString("user")
+	if userFlag != "" {
+		userID, err := res.ResolveUser(ctx, userFlag)
+		if err != nil {
+			return fmt.Errorf("failed to resolve user: %w", err)
+		}
+		userIDPtr = &userID
+	}
+
+	if err := client.IssueUnsubscribe(ctx, resolvedIssueID, userIDPtr); err != nil {
+		return fmt.Errorf("failed to unsubscribe from issue: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), map[string]any{
+		"success": true,
+		"issueId": issueID,
+		"action":  "unsubscribed",
+	}, true)
+}

--- a/internal/graphql/client.go
+++ b/internal/graphql/client.go
@@ -74,6 +74,8 @@ type LinearGraphQLClient interface {
 	DeleteIssue(ctx context.Context, id string, permanentlyDelete *bool, interceptors ...clientv2.RequestInterceptor) (*DeleteIssue, error)
 	ArchiveIssue(ctx context.Context, id string, trash *bool, interceptors ...clientv2.RequestInterceptor) (*ArchiveIssue, error)
 	UnarchiveIssue(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*UnarchiveIssue, error)
+	IssueSubscribe(ctx context.Context, id string, userID *string, interceptors ...clientv2.RequestInterceptor) (*IssueSubscribe, error)
+	IssueUnsubscribe(ctx context.Context, id string, userID *string, interceptors ...clientv2.RequestInterceptor) (*IssueUnsubscribe, error)
 	CreateLabel(ctx context.Context, input IssueLabelCreateInput, interceptors ...clientv2.RequestInterceptor) (*CreateLabel, error)
 	UpdateLabel(ctx context.Context, id string, input IssueLabelUpdateInput, interceptors ...clientv2.RequestInterceptor) (*UpdateLabel, error)
 	DeleteLabel(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*DeleteLabel, error)
@@ -5363,6 +5365,28 @@ func (t *UnarchiveIssue_IssueUnarchive) GetSuccess() bool {
 	return t.Success
 }
 
+type IssueSubscribe_IssueSubscribe struct {
+	Success bool "json:\"success\" graphql:\"success\""
+}
+
+func (t *IssueSubscribe_IssueSubscribe) GetSuccess() bool {
+	if t == nil {
+		t = &IssueSubscribe_IssueSubscribe{}
+	}
+	return t.Success
+}
+
+type IssueUnsubscribe_IssueUnsubscribe struct {
+	Success bool "json:\"success\" graphql:\"success\""
+}
+
+func (t *IssueUnsubscribe_IssueUnsubscribe) GetSuccess() bool {
+	if t == nil {
+		t = &IssueUnsubscribe_IssueUnsubscribe{}
+	}
+	return t.Success
+}
+
 type CreateLabel_IssueLabelCreate_IssueLabel struct {
 	Color       string    "json:\"color\" graphql:\"color\""
 	CreatedAt   time.Time "json:\"createdAt\" graphql:\"createdAt\""
@@ -9771,6 +9795,28 @@ func (t *UnarchiveIssue) GetIssueUnarchive() *UnarchiveIssue_IssueUnarchive {
 	return &t.IssueUnarchive
 }
 
+type IssueSubscribe struct {
+	IssueSubscribe IssueSubscribe_IssueSubscribe "json:\"issueSubscribe\" graphql:\"issueSubscribe\""
+}
+
+func (t *IssueSubscribe) GetIssueSubscribe() *IssueSubscribe_IssueSubscribe {
+	if t == nil {
+		t = &IssueSubscribe{}
+	}
+	return &t.IssueSubscribe
+}
+
+type IssueUnsubscribe struct {
+	IssueUnsubscribe IssueUnsubscribe_IssueUnsubscribe "json:\"issueUnsubscribe\" graphql:\"issueUnsubscribe\""
+}
+
+func (t *IssueUnsubscribe) GetIssueUnsubscribe() *IssueUnsubscribe_IssueUnsubscribe {
+	if t == nil {
+		t = &IssueUnsubscribe{}
+	}
+	return &t.IssueUnsubscribe
+}
+
 type CreateLabel struct {
 	IssueLabelCreate CreateLabel_IssueLabelCreate "json:\"issueLabelCreate\" graphql:\"issueLabelCreate\""
 }
@@ -12612,6 +12658,56 @@ func (c *Client) UnarchiveIssue(ctx context.Context, id string, interceptors ...
 	return &res, nil
 }
 
+const IssueSubscribeDocument = `mutation IssueSubscribe ($id: String!, $userId: String) {
+	issueSubscribe(id: $id, userId: $userId) {
+		success
+	}
+}
+`
+
+func (c *Client) IssueSubscribe(ctx context.Context, id string, userID *string, interceptors ...clientv2.RequestInterceptor) (*IssueSubscribe, error) {
+	vars := map[string]any{
+		"id":     id,
+		"userId": userID,
+	}
+
+	var res IssueSubscribe
+	if err := c.Client.Post(ctx, "IssueSubscribe", IssueSubscribeDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const IssueUnsubscribeDocument = `mutation IssueUnsubscribe ($id: String!, $userId: String) {
+	issueUnsubscribe(id: $id, userId: $userId) {
+		success
+	}
+}
+`
+
+func (c *Client) IssueUnsubscribe(ctx context.Context, id string, userID *string, interceptors ...clientv2.RequestInterceptor) (*IssueUnsubscribe, error) {
+	vars := map[string]any{
+		"id":     id,
+		"userId": userID,
+	}
+
+	var res IssueUnsubscribe
+	if err := c.Client.Post(ctx, "IssueUnsubscribe", IssueUnsubscribeDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
 const CreateLabelDocument = `mutation CreateLabel ($input: IssueLabelCreateInput!) {
 	issueLabelCreate(input: $input) {
 		success
@@ -14403,6 +14499,8 @@ var DocumentOperationNames = map[string]string{
 	DeleteIssueDocument:                    "DeleteIssue",
 	ArchiveIssueDocument:                   "ArchiveIssue",
 	UnarchiveIssueDocument:                 "UnarchiveIssue",
+	IssueSubscribeDocument:                 "IssueSubscribe",
+	IssueUnsubscribeDocument:               "IssueUnsubscribe",
 	CreateLabelDocument:                    "CreateLabel",
 	UpdateLabelDocument:                    "UpdateLabel",
 	DeleteLabelDocument:                    "DeleteLabel",

--- a/pkg/linear/client_issue_subscribe.go
+++ b/pkg/linear/client_issue_subscribe.go
@@ -1,0 +1,53 @@
+package linear
+
+import (
+	"context"
+)
+
+// IssueSubscribe subscribes a user to an issue's notifications.
+//
+// Parameters:
+//   - id: Issue UUID to subscribe to (required)
+//   - userID: User UUID to subscribe (nil = current user)
+//
+// Returns:
+//   - nil: Successfully subscribed
+//   - error: Non-nil if subscription fails or Success is false
+//
+// Permissions Required: Write
+//
+// Related: [IssueUnsubscribe]
+func (c *Client) IssueSubscribe(ctx context.Context, id string, userID *string) error {
+	resp, err := c.gqlClient.IssueSubscribe(ctx, id, userID)
+	if err != nil {
+		return wrapGraphQLError("IssueSubscribe", err)
+	}
+	if !resp.IssueSubscribe.Success {
+		return errMutationFailed("IssueSubscribe")
+	}
+	return nil
+}
+
+// IssueUnsubscribe unsubscribes a user from an issue's notifications.
+//
+// Parameters:
+//   - id: Issue UUID to unsubscribe from (required)
+//   - userID: User UUID to unsubscribe (nil = current user)
+//
+// Returns:
+//   - nil: Successfully unsubscribed
+//   - error: Non-nil if unsubscription fails or Success is false
+//
+// Permissions Required: Write
+//
+// Related: [IssueSubscribe]
+func (c *Client) IssueUnsubscribe(ctx context.Context, id string, userID *string) error {
+	resp, err := c.gqlClient.IssueUnsubscribe(ctx, id, userID)
+	if err != nil {
+		return wrapGraphQLError("IssueUnsubscribe", err)
+	}
+	if !resp.IssueUnsubscribe.Success {
+		return errMutationFailed("IssueUnsubscribe")
+	}
+	return nil
+}

--- a/queries/mutations/issues.graphql
+++ b/queries/mutations/issues.graphql
@@ -58,3 +58,15 @@ mutation UnarchiveIssue($id: String!) {
     success
   }
 }
+
+mutation IssueSubscribe($id: String!, $userId: String) {
+  issueSubscribe(id: $id, userId: $userId) {
+    success
+  }
+}
+
+mutation IssueUnsubscribe($id: String!, $userId: String) {
+  issueUnsubscribe(id: $id, userId: $userId) {
+    success
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `issue subscribe` and `issue unsubscribe` commands
- Supports `--user` flag to subscribe/unsubscribe another user by name, email, or ID
- New GraphQL mutations, client methods, and CLI commands

Closes #50

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./cmd/linear/commands/issue/ ./pkg/linear/` passes
- [ ] Manual: `go-linear issue subscribe ENG-123`
- [ ] Manual: `go-linear issue unsubscribe ENG-123`

🤖 Generated with [Claude Code](https://claude.com/claude-code)