### PR TITLE
feat(custom-view): add custom view management commands

### DIFF
--- a/cmd/linear/commands/customview/create.go
+++ b/cmd/linear/commands/customview/create.go
@@ -108,7 +108,7 @@ func parseFilterData(value string) (*intgraphql.IssueFilter, error) {
 	var jsonData string
 
 	if filename, ok := strings.CutPrefix(value, "@"); ok {
-		data, err := os.ReadFile(filename) //nolint:gosec // user-provided filename is intentional CLI behavior // #nosec G304
+		data, err := os.ReadFile(filename) // #nosec G304 -- user-provided filename is intentional CLI behavior
 		if err != nil {
 			return nil, fmt.Errorf("reading file %s: %w", filename, err)
 		}

--- a/cmd/linear/commands/customview/create.go
+++ b/cmd/linear/commands/customview/create.go
@@ -1,0 +1,127 @@
+package customview
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/resolver"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewCreateCommand creates the custom-view create command.
+func NewCreateCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new custom view",
+		Long: `Create a custom view. Safe operation.
+
+Required: --name
+Optional: --description, --icon, --color, --team, --shared, --filter-data
+
+--filter-data accepts a JSON string or @filename for IssueFilter JSON.
+
+Example: go-linear custom-view create --name="My Bugs" --filter-data='{"priority":{"lte":2}}'
+         go-linear custom-view create --name="Team View" --team=ENG --shared
+
+Related: custom-view_get, custom-view_list`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runCreate(cmd, client)
+		},
+	}
+
+	cmd.Flags().String("name", "", "Custom view name (required)")
+	_ = cmd.MarkFlagRequired("name")
+	cmd.Flags().String("description", "", "Custom view description")
+	cmd.Flags().String("icon", "", "Custom view icon")
+	cmd.Flags().String("color", "", "Icon color")
+	cmd.Flags().String("team", "", "Team name, key, or UUID")
+	cmd.Flags().Bool("shared", false, "Share with organization")
+	cmd.Flags().String("filter-data", "", "Issue filter JSON string or @filename")
+
+	return cmd
+}
+
+func runCreate(cmd *cobra.Command, client *linear.Client) error {
+	ctx := cmd.Context()
+
+	name, _ := cmd.Flags().GetString("name")
+	input := intgraphql.CustomViewCreateInput{
+		Name: name,
+	}
+
+	if description, _ := cmd.Flags().GetString("description"); description != "" {
+		input.Description = &description
+	}
+
+	if icon, _ := cmd.Flags().GetString("icon"); icon != "" {
+		input.Icon = &icon
+	}
+
+	if color, _ := cmd.Flags().GetString("color"); color != "" {
+		input.Color = &color
+	}
+
+	if shared, _ := cmd.Flags().GetBool("shared"); cmd.Flags().Changed("shared") {
+		input.Shared = &shared
+	}
+
+	if team, _ := cmd.Flags().GetString("team"); team != "" {
+		res := resolver.New(client)
+		teamID, err := res.ResolveTeam(ctx, team)
+		if err != nil {
+			return fmt.Errorf("failed to resolve team: %w", err)
+		}
+		input.TeamID = &teamID
+	}
+
+	if filterData, _ := cmd.Flags().GetString("filter-data"); filterData != "" {
+		filter, err := parseFilterData(filterData)
+		if err != nil {
+			return fmt.Errorf("invalid --filter-data: %w", err)
+		}
+		input.FilterData = filter
+	}
+
+	result, err := client.CustomViewCreate(ctx, input)
+	if err != nil {
+		return fmt.Errorf("failed to create custom view: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), result, true)
+}
+
+// parseFilterData parses a JSON string or @filename into an IssueFilter.
+func parseFilterData(value string) (*intgraphql.IssueFilter, error) {
+	var jsonData string
+
+	if strings.HasPrefix(value, "@") {
+		filename := strings.TrimPrefix(value, "@")
+		data, err := os.ReadFile(filename)
+		if err != nil {
+			return nil, fmt.Errorf("reading file %s: %w", filename, err)
+		}
+		jsonData = string(data)
+	} else {
+		jsonData = value
+	}
+
+	var filter intgraphql.IssueFilter
+	if err := json.Unmarshal([]byte(jsonData), &filter); err != nil {
+		return nil, fmt.Errorf("parsing JSON: %w", err)
+	}
+
+	return &filter, nil
+}

--- a/cmd/linear/commands/customview/create.go
+++ b/cmd/linear/commands/customview/create.go
@@ -107,9 +107,8 @@ func runCreate(cmd *cobra.Command, client *linear.Client) error {
 func parseFilterData(value string) (*intgraphql.IssueFilter, error) {
 	var jsonData string
 
-	if strings.HasPrefix(value, "@") {
-		filename := strings.TrimPrefix(value, "@")
-		data, err := os.ReadFile(filename)
+	if filename, ok := strings.CutPrefix(value, "@"); ok {
+		data, err := os.ReadFile(filename) //nolint:gosec // user-provided filename is intentional CLI behavior // #nosec G304
 		if err != nil {
 			return nil, fmt.Errorf("reading file %s: %w", filename, err)
 		}

--- a/cmd/linear/commands/customview/customview.go
+++ b/cmd/linear/commands/customview/customview.go
@@ -1,0 +1,26 @@
+// Package customview provides custom view commands for the Linear CLI.
+package customview
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+)
+
+// NewCustomViewCommand creates the custom-view command group.
+func NewCustomViewCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "custom-view",
+		Aliases: []string{"cv"},
+		Short:   "Manage Linear custom views",
+		Long:    "Commands for listing, viewing, creating, updating, and deleting Linear custom views (saved filtered views).",
+	}
+
+	cmd.AddCommand(NewListCommand(clientFactory))
+	cmd.AddCommand(NewGetCommand(clientFactory))
+	cmd.AddCommand(NewCreateCommand(clientFactory))
+	cmd.AddCommand(NewUpdateCommand(clientFactory))
+	cmd.AddCommand(NewDeleteCommand(clientFactory))
+
+	return cmd
+}

--- a/cmd/linear/commands/customview/customview_test.go
+++ b/cmd/linear/commands/customview/customview_test.go
@@ -1,0 +1,109 @@
+package customview
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/testutil"
+)
+
+func TestNewCustomViewCommand(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewCustomViewCommand(factory)
+	if cmd.Use != "custom-view" {
+		t.Errorf("Use = %q, want %q", cmd.Use, "custom-view")
+	}
+	if len(cmd.Commands()) != 5 {
+		t.Errorf("Expected 5 subcommands, got %d", len(cmd.Commands()))
+	}
+}
+
+func TestRunList(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	t.Run("list json output", func(t *testing.T) {
+		cmd := NewListCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("Output should be valid JSON: %v", err)
+		}
+		if _, ok := result["nodes"]; !ok {
+			t.Error("Expected 'nodes' field in output")
+		}
+	})
+
+	t.Run("list with fields", func(t *testing.T) {
+		cmd := NewListCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"--fields=id,name"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+}
+
+func TestRunGet(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewGetCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cv-123"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Output should be valid JSON: %v", err)
+	}
+}
+
+func TestRunCreate(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewCreateCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--name=Test View"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestRunDelete(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewDeleteCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cv-123"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}

--- a/cmd/linear/commands/customview/delete.go
+++ b/cmd/linear/commands/customview/delete.go
@@ -1,0 +1,66 @@
+package customview
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewDeleteCommand creates the custom-view delete command.
+func NewDeleteCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	confirmFlags := &cli.ConfirmationFlags{}
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a custom view",
+		Long: `Delete a custom view. Cannot be undone. Prompts unless --yes.
+
+Example: go-linear custom-view delete <uuid>
+         go-linear custom-view delete <uuid> --yes
+
+Related: custom-view_list, custom-view_get`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runDelete(cmd, client, args[0], confirmFlags)
+		},
+	}
+
+	confirmFlags.Bind(cmd)
+
+	return cmd
+}
+
+func runDelete(cmd *cobra.Command, client *linear.Client, id string, confirmFlags *cli.ConfirmationFlags) error {
+	ctx := cmd.Context()
+
+	if !confirmFlags.Yes {
+		fmt.Fprintf(cmd.OutOrStderr(), "Delete custom view %s? This cannot be undone.\n", id)
+		fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
+		reader := bufio.NewReader(os.Stdin)
+		response, _ := reader.ReadString('\n')
+		if !strings.EqualFold(strings.TrimSpace(response), "yes") {
+			fmt.Fprintln(cmd.OutOrStderr(), "Canceled.")
+			return nil
+		}
+	}
+
+	err := client.CustomViewDelete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete custom view: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), map[string]bool{"success": true}, true)
+}

--- a/cmd/linear/commands/customview/get.go
+++ b/cmd/linear/commands/customview/get.go
@@ -1,0 +1,63 @@
+package customview
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/config"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/fieldfilter"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewGetCommand creates the custom-view get command.
+func NewGetCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get a custom view by ID",
+		Long: `Get custom view by UUID. Returns detailed fields including filterData.
+
+Example: go-linear custom-view get <uuid>
+
+Related: custom-view_list, custom-view_update`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runGet(cmd, client, args[0])
+		},
+	}
+
+	cmd.Flags().String("fields", "", "defaults (id,name,description,filterData,shared) | none | defaults,extra")
+
+	return cmd
+}
+
+func runGet(cmd *cobra.Command, client *linear.Client, id string) error {
+	ctx := cmd.Context()
+
+	view, err := client.CustomView(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to get custom view: %w", err)
+	}
+
+	fieldsSpec, _ := cmd.Flags().GetString("fields")
+
+	cfg, _ := config.Load()
+	var configOverrides map[string]string
+	if cfg != nil {
+		configOverrides = cfg.FieldDefaults
+	}
+	defaults := fieldfilter.GetDefaults("custom-view.get", configOverrides)
+	fieldSelector, err := fieldfilter.New(fieldsSpec, defaults)
+	if err != nil {
+		return fmt.Errorf("invalid --fields: %w", err)
+	}
+	return formatter.FormatJSONFiltered(cmd.OutOrStdout(), view, true, fieldSelector)
+}

--- a/cmd/linear/commands/customview/helpers_test.go
+++ b/cmd/linear/commands/customview/helpers_test.go
@@ -1,0 +1,70 @@
+package customview
+
+const (
+	mockCustomViewsResponse = `{
+		"data": {
+			"customViews": {
+				"nodes": [
+					{"id": "cv-123", "name": "My View", "shared": true, "modelName": "issue"}
+				],
+				"pageInfo": {"hasNextPage": false}
+			}
+		}
+	}`
+
+	mockCustomViewResponse = `{
+		"data": {
+			"customView": {
+				"id": "cv-123",
+				"name": "My View",
+				"description": "A test view",
+				"filterData": {"state": {"name": {"eq": "In Progress"}}},
+				"shared": true,
+				"modelName": "issue"
+			}
+		}
+	}`
+
+	mockCustomViewCreateResponse = `{
+		"data": {
+			"customViewCreate": {
+				"success": true,
+				"customView": {
+					"id": "cv-999",
+					"name": "New View",
+					"shared": false
+				}
+			}
+		}
+	}`
+
+	mockCustomViewUpdateResponse = `{
+		"data": {
+			"customViewUpdate": {
+				"success": true,
+				"customView": {
+					"id": "cv-123",
+					"name": "Updated View"
+				}
+			}
+		}
+	}`
+
+	mockCustomViewDeleteResponse = `{
+		"data": {
+			"customViewDelete": {
+				"success": true
+			}
+		}
+	}`
+)
+
+func defaultHandlers() map[string]string {
+	return map[string]string{
+		"ListCustomViews":  mockCustomViewsResponse,
+		"GetCustomView":    mockCustomViewResponse,
+		"CreateCustomView": mockCustomViewCreateResponse,
+		"UpdateCustomView": mockCustomViewUpdateResponse,
+		"DeleteCustomView": mockCustomViewDeleteResponse,
+	}
+}

--- a/cmd/linear/commands/customview/list.go
+++ b/cmd/linear/commands/customview/list.go
@@ -1,0 +1,67 @@
+package customview
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/config"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/fieldfilter"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewListCommand creates the custom-view list command.
+func NewListCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List custom views",
+		Long: `List custom views. Returns default fields per view.
+
+Example: go-linear custom-view list
+         go-linear custom-view list --limit=10
+
+Related: custom-view_get, custom-view_create`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runList(cmd, client)
+		},
+	}
+
+	cmd.Flags().IntP("limit", "l", 50, "Number to return")
+	cmd.Flags().String("fields", "", "defaults (id,name,shared,modelName) | none | defaults,extra")
+
+	return cmd
+}
+
+func runList(cmd *cobra.Command, client *linear.Client) error {
+	ctx := cmd.Context()
+
+	limit, _ := cmd.Flags().GetInt("limit")
+	first := int64(limit)
+
+	views, err := client.CustomViews(ctx, &first, nil)
+	if err != nil {
+		return fmt.Errorf("failed to list custom views: %w", err)
+	}
+
+	fieldsSpec, _ := cmd.Flags().GetString("fields")
+
+	cfg, _ := config.Load()
+	var configOverrides map[string]string
+	if cfg != nil {
+		configOverrides = cfg.FieldDefaults
+	}
+	defaults := fieldfilter.GetDefaults("custom-view.list", configOverrides)
+	fieldSelector, err := fieldfilter.NewForList(fieldsSpec, defaults)
+	if err != nil {
+		return fmt.Errorf("invalid --fields: %w", err)
+	}
+	return formatter.FormatJSONFiltered(cmd.OutOrStdout(), views, true, fieldSelector)
+}

--- a/cmd/linear/commands/customview/update.go
+++ b/cmd/linear/commands/customview/update.go
@@ -1,0 +1,112 @@
+package customview
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/resolver"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewUpdateCommand creates the custom-view update command.
+func NewUpdateCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a custom view",
+		Long: `Update an existing custom view. Modifies existing data.
+
+Fields: --name, --description, --icon, --color, --shared, --filter-data, --team
+
+Example: go-linear custom-view update <uuid> --name="Updated View"
+         go-linear custom-view update <uuid> --shared=true --filter-data='{"priority":{"lte":1}}'
+
+Related: custom-view_get, custom-view_create`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runUpdate(cmd, client, args[0])
+		},
+	}
+
+	cmd.Flags().String("name", "", "New custom view name")
+	cmd.Flags().String("description", "", "New description")
+	cmd.Flags().String("icon", "", "New icon")
+	cmd.Flags().String("color", "", "New icon color")
+	cmd.Flags().String("team", "", "Team name, key, or UUID")
+	cmd.Flags().Bool("shared", false, "Share with organization")
+	cmd.Flags().String("filter-data", "", "Issue filter JSON string or @filename")
+
+	return cmd
+}
+
+func runUpdate(cmd *cobra.Command, client *linear.Client, id string) error {
+	ctx := cmd.Context()
+
+	input := intgraphql.CustomViewUpdateInput{}
+	updated := false
+
+	if name, _ := cmd.Flags().GetString("name"); name != "" {
+		input.Name = &name
+		updated = true
+	}
+
+	if description, _ := cmd.Flags().GetString("description"); description != "" {
+		input.Description = &description
+		updated = true
+	}
+
+	if icon, _ := cmd.Flags().GetString("icon"); icon != "" {
+		input.Icon = &icon
+		updated = true
+	}
+
+	if color, _ := cmd.Flags().GetString("color"); color != "" {
+		input.Color = &color
+		updated = true
+	}
+
+	if cmd.Flags().Changed("shared") {
+		shared, _ := cmd.Flags().GetBool("shared")
+		input.Shared = &shared
+		updated = true
+	}
+
+	if team, _ := cmd.Flags().GetString("team"); team != "" {
+		res := resolver.New(client)
+		teamID, err := res.ResolveTeam(ctx, team)
+		if err != nil {
+			return fmt.Errorf("failed to resolve team: %w", err)
+		}
+		input.TeamID = &teamID
+		updated = true
+	}
+
+	if filterData, _ := cmd.Flags().GetString("filter-data"); filterData != "" {
+		filter, err := parseFilterData(filterData)
+		if err != nil {
+			return fmt.Errorf("invalid --filter-data: %w", err)
+		}
+		input.FilterData = filter
+		updated = true
+	}
+
+	if !updated {
+		return fmt.Errorf("no fields to update specified")
+	}
+
+	result, err := client.CustomViewUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("failed to update custom view: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), result, true)
+}

--- a/cmd/linear/commands/root.go
+++ b/cmd/linear/commands/root.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/attachment"
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/comment"
+	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/customview"
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/cycle"
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/document"
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/favorite"
@@ -299,6 +300,7 @@ Environment Variables:
 	// Add subcommands (ordered alphabetically)
 	rootCmd.AddCommand(attachment.NewAttachmentCommand(getClient))
 	rootCmd.AddCommand(comment.NewCommentCommand(getClient))
+	rootCmd.AddCommand(customview.NewCustomViewCommand(getClient))
 	rootCmd.AddCommand(cycle.NewCycleCommand(getClient))
 	rootCmd.AddCommand(document.NewDocumentCommand(getClient))
 	rootCmd.AddCommand(favorite.NewFavoriteCommand(getClient))

--- a/internal/fieldfilter/defaults.go
+++ b/internal/fieldfilter/defaults.go
@@ -125,6 +125,14 @@ var BuiltinDefaults = map[string][]string{
 		"id", "name", "description", "templateData", "createdAt",
 	},
 
+	// Custom view commands
+	"custom-view.list": {
+		"id", "name", "shared", "modelName",
+	},
+	"custom-view.get": {
+		"id", "name", "description", "filterData", "shared",
+	},
+
 	// Favorite commands (no list, only create/delete)
 
 	// Reaction commands (no list, only create/delete)

--- a/internal/graphql/client.go
+++ b/internal/graphql/client.go
@@ -17,6 +17,8 @@ type LinearGraphQLClient interface {
 	GetComment(ctx context.Context, id string, childrenLimit *int64, childrenAfter *string, interceptors ...clientv2.RequestInterceptor) (*GetComment, error)
 	ListComments(ctx context.Context, first *int64, after *string, interceptors ...clientv2.RequestInterceptor) (*ListComments, error)
 	ListCommentsFiltered(ctx context.Context, first *int64, after *string, filter *CommentFilter, interceptors ...clientv2.RequestInterceptor) (*ListCommentsFiltered, error)
+	GetCustomView(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*GetCustomView, error)
+	ListCustomViews(ctx context.Context, first *int64, after *string, interceptors ...clientv2.RequestInterceptor) (*ListCustomViews, error)
 	GetCycle(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*GetCycle, error)
 	ListCycles(ctx context.Context, first *int64, after *string, interceptors ...clientv2.RequestInterceptor) (*ListCycles, error)
 	ListCyclesFiltered(ctx context.Context, first *int64, after *string, filter *CycleFilter, interceptors ...clientv2.RequestInterceptor) (*ListCyclesFiltered, error)
@@ -46,6 +48,9 @@ type LinearGraphQLClient interface {
 	CreateComment(ctx context.Context, input CommentCreateInput, interceptors ...clientv2.RequestInterceptor) (*CreateComment, error)
 	UpdateComment(ctx context.Context, id string, input CommentUpdateInput, interceptors ...clientv2.RequestInterceptor) (*UpdateComment, error)
 	DeleteComment(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*DeleteComment, error)
+	CreateCustomView(ctx context.Context, input CustomViewCreateInput, interceptors ...clientv2.RequestInterceptor) (*CreateCustomView, error)
+	UpdateCustomView(ctx context.Context, id string, input CustomViewUpdateInput, interceptors ...clientv2.RequestInterceptor) (*UpdateCustomView, error)
+	DeleteCustomView(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*DeleteCustomView, error)
 	CreateCycle(ctx context.Context, input CycleCreateInput, interceptors ...clientv2.RequestInterceptor) (*CreateCycle, error)
 	UpdateCycle(ctx context.Context, id string, input CycleUpdateInput, interceptors ...clientv2.RequestInterceptor) (*UpdateCycle, error)
 	ArchiveCycle(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*ArchiveCycle, error)
@@ -922,6 +927,336 @@ func (t *ListCommentsFiltered_Comments) GetNodes() []*ListCommentsFiltered_Comme
 func (t *ListCommentsFiltered_Comments) GetPageInfo() *ListCommentsFiltered_Comments_PageInfo {
 	if t == nil {
 		t = &ListCommentsFiltered_Comments{}
+	}
+	return &t.PageInfo
+}
+
+type GetCustomView_CustomView_Creator struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *GetCustomView_CustomView_Creator) GetID() string {
+	if t == nil {
+		t = &GetCustomView_CustomView_Creator{}
+	}
+	return t.ID
+}
+func (t *GetCustomView_CustomView_Creator) GetName() string {
+	if t == nil {
+		t = &GetCustomView_CustomView_Creator{}
+	}
+	return t.Name
+}
+
+type GetCustomView_CustomView_Owner struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *GetCustomView_CustomView_Owner) GetID() string {
+	if t == nil {
+		t = &GetCustomView_CustomView_Owner{}
+	}
+	return t.ID
+}
+func (t *GetCustomView_CustomView_Owner) GetName() string {
+	if t == nil {
+		t = &GetCustomView_CustomView_Owner{}
+	}
+	return t.Name
+}
+
+type GetCustomView_CustomView_Team struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Key  string "json:\"key\" graphql:\"key\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *GetCustomView_CustomView_Team) GetID() string {
+	if t == nil {
+		t = &GetCustomView_CustomView_Team{}
+	}
+	return t.ID
+}
+func (t *GetCustomView_CustomView_Team) GetKey() string {
+	if t == nil {
+		t = &GetCustomView_CustomView_Team{}
+	}
+	return t.Key
+}
+func (t *GetCustomView_CustomView_Team) GetName() string {
+	if t == nil {
+		t = &GetCustomView_CustomView_Team{}
+	}
+	return t.Name
+}
+
+type GetCustomView_CustomView struct {
+	Color                *string                          "json:\"color,omitempty\" graphql:\"color\""
+	CreatedAt            time.Time                        "json:\"createdAt\" graphql:\"createdAt\""
+	Creator              GetCustomView_CustomView_Creator "json:\"creator\" graphql:\"creator\""
+	Description          *string                          "json:\"description,omitempty\" graphql:\"description\""
+	FilterData           map[string]any                   "json:\"filterData\" graphql:\"filterData\""
+	Icon                 *string                          "json:\"icon,omitempty\" graphql:\"icon\""
+	ID                   string                           "json:\"id\" graphql:\"id\""
+	InitiativeFilterData map[string]any                   "json:\"initiativeFilterData,omitempty\" graphql:\"initiativeFilterData\""
+	ModelName            string                           "json:\"modelName\" graphql:\"modelName\""
+	Name                 string                           "json:\"name\" graphql:\"name\""
+	Owner                GetCustomView_CustomView_Owner   "json:\"owner\" graphql:\"owner\""
+	ProjectFilterData    map[string]any                   "json:\"projectFilterData,omitempty\" graphql:\"projectFilterData\""
+	Shared               bool                             "json:\"shared\" graphql:\"shared\""
+	Team                 *GetCustomView_CustomView_Team   "json:\"team,omitempty\" graphql:\"team\""
+	UpdatedAt            time.Time                        "json:\"updatedAt\" graphql:\"updatedAt\""
+}
+
+func (t *GetCustomView_CustomView) GetColor() *string {
+	if t == nil {
+		t = &GetCustomView_CustomView{}
+	}
+	return t.Color
+}
+func (t *GetCustomView_CustomView) GetCreatedAt() *time.Time {
+	if t == nil {
+		t = &GetCustomView_CustomView{}
+	}
+	return &t.CreatedAt
+}
+func (t *GetCustomView_CustomView) GetCreator() *GetCustomView_CustomView_Creator {
+	if t == nil {
+		t = &GetCustomView_CustomView{}
+	}
+	return &t.Creator
+}
+func (t *GetCustomView_CustomView) GetDescription() *string {
+	if t == nil {
+		t = &GetCustomView_CustomView{}
+	}
+	return t.Description
+}
+func (t *GetCustomView_CustomView) GetFilterData() map[string]any {
+	if t == nil {
+		t = &GetCustomView_CustomView{}
+	}
+	return t.FilterData
+}
+func (t *GetCustomView_CustomView) GetIcon() *string {
+	if t == nil {
+		t = &GetCustomView_CustomView{}
+	}
+	return t.Icon
+}
+func (t *GetCustomView_CustomView) GetID() string {
+	if t == nil {
+		t = &GetCustomView_CustomView{}
+	}
+	return t.ID
+}
+func (t *GetCustomView_CustomView) GetInitiativeFilterData() map[string]any {
+	if t == nil {
+		t = &GetCustomView_CustomView{}
+	}
+	return t.InitiativeFilterData
+}
+func (t *GetCustomView_CustomView) GetModelName() string {
+	if t == nil {
+		t = &GetCustomView_CustomView{}
+	}
+	return t.ModelName
+}
+func (t *GetCustomView_CustomView) GetName() string {
+	if t == nil {
+		t = &GetCustomView_CustomView{}
+	}
+	return t.Name
+}
+func (t *GetCustomView_CustomView) GetOwner() *GetCustomView_CustomView_Owner {
+	if t == nil {
+		t = &GetCustomView_CustomView{}
+	}
+	return &t.Owner
+}
+func (t *GetCustomView_CustomView) GetProjectFilterData() map[string]any {
+	if t == nil {
+		t = &GetCustomView_CustomView{}
+	}
+	return t.ProjectFilterData
+}
+func (t *GetCustomView_CustomView) GetShared() bool {
+	if t == nil {
+		t = &GetCustomView_CustomView{}
+	}
+	return t.Shared
+}
+func (t *GetCustomView_CustomView) GetTeam() *GetCustomView_CustomView_Team {
+	if t == nil {
+		t = &GetCustomView_CustomView{}
+	}
+	return t.Team
+}
+func (t *GetCustomView_CustomView) GetUpdatedAt() *time.Time {
+	if t == nil {
+		t = &GetCustomView_CustomView{}
+	}
+	return &t.UpdatedAt
+}
+
+type ListCustomViews_CustomViews_Nodes_Creator struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *ListCustomViews_CustomViews_Nodes_Creator) GetID() string {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_Nodes_Creator{}
+	}
+	return t.ID
+}
+func (t *ListCustomViews_CustomViews_Nodes_Creator) GetName() string {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_Nodes_Creator{}
+	}
+	return t.Name
+}
+
+type ListCustomViews_CustomViews_Nodes_Team struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Key  string "json:\"key\" graphql:\"key\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *ListCustomViews_CustomViews_Nodes_Team) GetID() string {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_Nodes_Team{}
+	}
+	return t.ID
+}
+func (t *ListCustomViews_CustomViews_Nodes_Team) GetKey() string {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_Nodes_Team{}
+	}
+	return t.Key
+}
+func (t *ListCustomViews_CustomViews_Nodes_Team) GetName() string {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_Nodes_Team{}
+	}
+	return t.Name
+}
+
+type ListCustomViews_CustomViews_Nodes struct {
+	Color       *string                                   "json:\"color,omitempty\" graphql:\"color\""
+	CreatedAt   time.Time                                 "json:\"createdAt\" graphql:\"createdAt\""
+	Creator     ListCustomViews_CustomViews_Nodes_Creator "json:\"creator\" graphql:\"creator\""
+	Description *string                                   "json:\"description,omitempty\" graphql:\"description\""
+	Icon        *string                                   "json:\"icon,omitempty\" graphql:\"icon\""
+	ID          string                                    "json:\"id\" graphql:\"id\""
+	ModelName   string                                    "json:\"modelName\" graphql:\"modelName\""
+	Name        string                                    "json:\"name\" graphql:\"name\""
+	Shared      bool                                      "json:\"shared\" graphql:\"shared\""
+	Team        *ListCustomViews_CustomViews_Nodes_Team   "json:\"team,omitempty\" graphql:\"team\""
+	UpdatedAt   time.Time                                 "json:\"updatedAt\" graphql:\"updatedAt\""
+}
+
+func (t *ListCustomViews_CustomViews_Nodes) GetColor() *string {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_Nodes{}
+	}
+	return t.Color
+}
+func (t *ListCustomViews_CustomViews_Nodes) GetCreatedAt() *time.Time {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_Nodes{}
+	}
+	return &t.CreatedAt
+}
+func (t *ListCustomViews_CustomViews_Nodes) GetCreator() *ListCustomViews_CustomViews_Nodes_Creator {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_Nodes{}
+	}
+	return &t.Creator
+}
+func (t *ListCustomViews_CustomViews_Nodes) GetDescription() *string {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_Nodes{}
+	}
+	return t.Description
+}
+func (t *ListCustomViews_CustomViews_Nodes) GetIcon() *string {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_Nodes{}
+	}
+	return t.Icon
+}
+func (t *ListCustomViews_CustomViews_Nodes) GetID() string {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_Nodes{}
+	}
+	return t.ID
+}
+func (t *ListCustomViews_CustomViews_Nodes) GetModelName() string {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_Nodes{}
+	}
+	return t.ModelName
+}
+func (t *ListCustomViews_CustomViews_Nodes) GetName() string {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_Nodes{}
+	}
+	return t.Name
+}
+func (t *ListCustomViews_CustomViews_Nodes) GetShared() bool {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_Nodes{}
+	}
+	return t.Shared
+}
+func (t *ListCustomViews_CustomViews_Nodes) GetTeam() *ListCustomViews_CustomViews_Nodes_Team {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_Nodes{}
+	}
+	return t.Team
+}
+func (t *ListCustomViews_CustomViews_Nodes) GetUpdatedAt() *time.Time {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_Nodes{}
+	}
+	return &t.UpdatedAt
+}
+
+type ListCustomViews_CustomViews_PageInfo struct {
+	EndCursor   *string "json:\"endCursor,omitempty\" graphql:\"endCursor\""
+	HasNextPage bool    "json:\"hasNextPage\" graphql:\"hasNextPage\""
+}
+
+func (t *ListCustomViews_CustomViews_PageInfo) GetEndCursor() *string {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_PageInfo{}
+	}
+	return t.EndCursor
+}
+func (t *ListCustomViews_CustomViews_PageInfo) GetHasNextPage() bool {
+	if t == nil {
+		t = &ListCustomViews_CustomViews_PageInfo{}
+	}
+	return t.HasNextPage
+}
+
+type ListCustomViews_CustomViews struct {
+	Nodes    []*ListCustomViews_CustomViews_Nodes "json:\"nodes\" graphql:\"nodes\""
+	PageInfo ListCustomViews_CustomViews_PageInfo "json:\"pageInfo\" graphql:\"pageInfo\""
+}
+
+func (t *ListCustomViews_CustomViews) GetNodes() []*ListCustomViews_CustomViews_Nodes {
+	if t == nil {
+		t = &ListCustomViews_CustomViews{}
+	}
+	return t.Nodes
+}
+func (t *ListCustomViews_CustomViews) GetPageInfo() *ListCustomViews_CustomViews_PageInfo {
+	if t == nil {
+		t = &ListCustomViews_CustomViews{}
 	}
 	return &t.PageInfo
 }
@@ -4034,6 +4369,187 @@ type DeleteComment_CommentDelete struct {
 func (t *DeleteComment_CommentDelete) GetSuccess() bool {
 	if t == nil {
 		t = &DeleteComment_CommentDelete{}
+	}
+	return t.Success
+}
+
+type CreateCustomView_CustomViewCreate_CustomView struct {
+	Color       *string        "json:\"color,omitempty\" graphql:\"color\""
+	CreatedAt   time.Time      "json:\"createdAt\" graphql:\"createdAt\""
+	Description *string        "json:\"description,omitempty\" graphql:\"description\""
+	FilterData  map[string]any "json:\"filterData\" graphql:\"filterData\""
+	Icon        *string        "json:\"icon,omitempty\" graphql:\"icon\""
+	ID          string         "json:\"id\" graphql:\"id\""
+	ModelName   string         "json:\"modelName\" graphql:\"modelName\""
+	Name        string         "json:\"name\" graphql:\"name\""
+	Shared      bool           "json:\"shared\" graphql:\"shared\""
+}
+
+func (t *CreateCustomView_CustomViewCreate_CustomView) GetColor() *string {
+	if t == nil {
+		t = &CreateCustomView_CustomViewCreate_CustomView{}
+	}
+	return t.Color
+}
+func (t *CreateCustomView_CustomViewCreate_CustomView) GetCreatedAt() *time.Time {
+	if t == nil {
+		t = &CreateCustomView_CustomViewCreate_CustomView{}
+	}
+	return &t.CreatedAt
+}
+func (t *CreateCustomView_CustomViewCreate_CustomView) GetDescription() *string {
+	if t == nil {
+		t = &CreateCustomView_CustomViewCreate_CustomView{}
+	}
+	return t.Description
+}
+func (t *CreateCustomView_CustomViewCreate_CustomView) GetFilterData() map[string]any {
+	if t == nil {
+		t = &CreateCustomView_CustomViewCreate_CustomView{}
+	}
+	return t.FilterData
+}
+func (t *CreateCustomView_CustomViewCreate_CustomView) GetIcon() *string {
+	if t == nil {
+		t = &CreateCustomView_CustomViewCreate_CustomView{}
+	}
+	return t.Icon
+}
+func (t *CreateCustomView_CustomViewCreate_CustomView) GetID() string {
+	if t == nil {
+		t = &CreateCustomView_CustomViewCreate_CustomView{}
+	}
+	return t.ID
+}
+func (t *CreateCustomView_CustomViewCreate_CustomView) GetModelName() string {
+	if t == nil {
+		t = &CreateCustomView_CustomViewCreate_CustomView{}
+	}
+	return t.ModelName
+}
+func (t *CreateCustomView_CustomViewCreate_CustomView) GetName() string {
+	if t == nil {
+		t = &CreateCustomView_CustomViewCreate_CustomView{}
+	}
+	return t.Name
+}
+func (t *CreateCustomView_CustomViewCreate_CustomView) GetShared() bool {
+	if t == nil {
+		t = &CreateCustomView_CustomViewCreate_CustomView{}
+	}
+	return t.Shared
+}
+
+type CreateCustomView_CustomViewCreate struct {
+	CustomView CreateCustomView_CustomViewCreate_CustomView "json:\"customView\" graphql:\"customView\""
+	Success    bool                                         "json:\"success\" graphql:\"success\""
+}
+
+func (t *CreateCustomView_CustomViewCreate) GetCustomView() *CreateCustomView_CustomViewCreate_CustomView {
+	if t == nil {
+		t = &CreateCustomView_CustomViewCreate{}
+	}
+	return &t.CustomView
+}
+func (t *CreateCustomView_CustomViewCreate) GetSuccess() bool {
+	if t == nil {
+		t = &CreateCustomView_CustomViewCreate{}
+	}
+	return t.Success
+}
+
+type UpdateCustomView_CustomViewUpdate_CustomView struct {
+	Color       *string        "json:\"color,omitempty\" graphql:\"color\""
+	Description *string        "json:\"description,omitempty\" graphql:\"description\""
+	FilterData  map[string]any "json:\"filterData\" graphql:\"filterData\""
+	Icon        *string        "json:\"icon,omitempty\" graphql:\"icon\""
+	ID          string         "json:\"id\" graphql:\"id\""
+	ModelName   string         "json:\"modelName\" graphql:\"modelName\""
+	Name        string         "json:\"name\" graphql:\"name\""
+	Shared      bool           "json:\"shared\" graphql:\"shared\""
+	UpdatedAt   time.Time      "json:\"updatedAt\" graphql:\"updatedAt\""
+}
+
+func (t *UpdateCustomView_CustomViewUpdate_CustomView) GetColor() *string {
+	if t == nil {
+		t = &UpdateCustomView_CustomViewUpdate_CustomView{}
+	}
+	return t.Color
+}
+func (t *UpdateCustomView_CustomViewUpdate_CustomView) GetDescription() *string {
+	if t == nil {
+		t = &UpdateCustomView_CustomViewUpdate_CustomView{}
+	}
+	return t.Description
+}
+func (t *UpdateCustomView_CustomViewUpdate_CustomView) GetFilterData() map[string]any {
+	if t == nil {
+		t = &UpdateCustomView_CustomViewUpdate_CustomView{}
+	}
+	return t.FilterData
+}
+func (t *UpdateCustomView_CustomViewUpdate_CustomView) GetIcon() *string {
+	if t == nil {
+		t = &UpdateCustomView_CustomViewUpdate_CustomView{}
+	}
+	return t.Icon
+}
+func (t *UpdateCustomView_CustomViewUpdate_CustomView) GetID() string {
+	if t == nil {
+		t = &UpdateCustomView_CustomViewUpdate_CustomView{}
+	}
+	return t.ID
+}
+func (t *UpdateCustomView_CustomViewUpdate_CustomView) GetModelName() string {
+	if t == nil {
+		t = &UpdateCustomView_CustomViewUpdate_CustomView{}
+	}
+	return t.ModelName
+}
+func (t *UpdateCustomView_CustomViewUpdate_CustomView) GetName() string {
+	if t == nil {
+		t = &UpdateCustomView_CustomViewUpdate_CustomView{}
+	}
+	return t.Name
+}
+func (t *UpdateCustomView_CustomViewUpdate_CustomView) GetShared() bool {
+	if t == nil {
+		t = &UpdateCustomView_CustomViewUpdate_CustomView{}
+	}
+	return t.Shared
+}
+func (t *UpdateCustomView_CustomViewUpdate_CustomView) GetUpdatedAt() *time.Time {
+	if t == nil {
+		t = &UpdateCustomView_CustomViewUpdate_CustomView{}
+	}
+	return &t.UpdatedAt
+}
+
+type UpdateCustomView_CustomViewUpdate struct {
+	CustomView UpdateCustomView_CustomViewUpdate_CustomView "json:\"customView\" graphql:\"customView\""
+	Success    bool                                         "json:\"success\" graphql:\"success\""
+}
+
+func (t *UpdateCustomView_CustomViewUpdate) GetCustomView() *UpdateCustomView_CustomViewUpdate_CustomView {
+	if t == nil {
+		t = &UpdateCustomView_CustomViewUpdate{}
+	}
+	return &t.CustomView
+}
+func (t *UpdateCustomView_CustomViewUpdate) GetSuccess() bool {
+	if t == nil {
+		t = &UpdateCustomView_CustomViewUpdate{}
+	}
+	return t.Success
+}
+
+type DeleteCustomView_CustomViewDelete struct {
+	Success bool "json:\"success\" graphql:\"success\""
+}
+
+func (t *DeleteCustomView_CustomViewDelete) GetSuccess() bool {
+	if t == nil {
+		t = &DeleteCustomView_CustomViewDelete{}
 	}
 	return t.Success
 }
@@ -9144,6 +9660,28 @@ func (t *ListCommentsFiltered) GetComments() *ListCommentsFiltered_Comments {
 	return &t.Comments
 }
 
+type GetCustomView struct {
+	CustomView GetCustomView_CustomView "json:\"customView\" graphql:\"customView\""
+}
+
+func (t *GetCustomView) GetCustomView() *GetCustomView_CustomView {
+	if t == nil {
+		t = &GetCustomView{}
+	}
+	return &t.CustomView
+}
+
+type ListCustomViews struct {
+	CustomViews ListCustomViews_CustomViews "json:\"customViews\" graphql:\"customViews\""
+}
+
+func (t *ListCustomViews) GetCustomViews() *ListCustomViews_CustomViews {
+	if t == nil {
+		t = &ListCustomViews{}
+	}
+	return &t.CustomViews
+}
+
 type GetCycle struct {
 	Cycle GetCycle_Cycle "json:\"cycle\" graphql:\"cycle\""
 }
@@ -9461,6 +9999,39 @@ func (t *DeleteComment) GetCommentDelete() *DeleteComment_CommentDelete {
 		t = &DeleteComment{}
 	}
 	return &t.CommentDelete
+}
+
+type CreateCustomView struct {
+	CustomViewCreate CreateCustomView_CustomViewCreate "json:\"customViewCreate\" graphql:\"customViewCreate\""
+}
+
+func (t *CreateCustomView) GetCustomViewCreate() *CreateCustomView_CustomViewCreate {
+	if t == nil {
+		t = &CreateCustomView{}
+	}
+	return &t.CustomViewCreate
+}
+
+type UpdateCustomView struct {
+	CustomViewUpdate UpdateCustomView_CustomViewUpdate "json:\"customViewUpdate\" graphql:\"customViewUpdate\""
+}
+
+func (t *UpdateCustomView) GetCustomViewUpdate() *UpdateCustomView_CustomViewUpdate {
+	if t == nil {
+		t = &UpdateCustomView{}
+	}
+	return &t.CustomViewUpdate
+}
+
+type DeleteCustomView struct {
+	CustomViewDelete DeleteCustomView_CustomViewDelete "json:\"customViewDelete\" graphql:\"customViewDelete\""
+}
+
+func (t *DeleteCustomView) GetCustomViewDelete() *DeleteCustomView_CustomViewDelete {
+	if t == nil {
+		t = &DeleteCustomView{}
+	}
+	return &t.CustomViewDelete
 }
 
 type CreateCycle struct {
@@ -10620,6 +11191,102 @@ func (c *Client) ListCommentsFiltered(ctx context.Context, first *int64, after *
 	return &res, nil
 }
 
+const GetCustomViewDocument = `query GetCustomView ($id: String!) {
+	customView(id: $id) {
+		id
+		name
+		description
+		icon
+		color
+		filterData
+		projectFilterData
+		initiativeFilterData
+		modelName
+		shared
+		createdAt
+		updatedAt
+		creator {
+			id
+			name
+		}
+		owner {
+			id
+			name
+		}
+		team {
+			id
+			name
+			key
+		}
+	}
+}
+`
+
+func (c *Client) GetCustomView(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*GetCustomView, error) {
+	vars := map[string]any{
+		"id": id,
+	}
+
+	var res GetCustomView
+	if err := c.Client.Post(ctx, "GetCustomView", GetCustomViewDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const ListCustomViewsDocument = `query ListCustomViews ($first: Int, $after: String) {
+	customViews(first: $first, after: $after) {
+		nodes {
+			id
+			name
+			description
+			icon
+			color
+			modelName
+			shared
+			createdAt
+			updatedAt
+			creator {
+				id
+				name
+			}
+			team {
+				id
+				name
+				key
+			}
+		}
+		pageInfo {
+			hasNextPage
+			endCursor
+		}
+	}
+}
+`
+
+func (c *Client) ListCustomViews(ctx context.Context, first *int64, after *string, interceptors ...clientv2.RequestInterceptor) (*ListCustomViews, error) {
+	vars := map[string]any{
+		"first": first,
+		"after": after,
+	}
+
+	var res ListCustomViews
+	if err := c.Client.Post(ctx, "ListCustomViews", ListCustomViewsDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
 const GetCycleDocument = `query GetCycle ($id: String!) {
 	cycle(id: $id) {
 		id
@@ -11762,6 +12429,101 @@ func (c *Client) DeleteComment(ctx context.Context, id string, interceptors ...c
 
 	var res DeleteComment
 	if err := c.Client.Post(ctx, "DeleteComment", DeleteCommentDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const CreateCustomViewDocument = `mutation CreateCustomView ($input: CustomViewCreateInput!) {
+	customViewCreate(input: $input) {
+		success
+		customView {
+			id
+			name
+			description
+			icon
+			color
+			filterData
+			modelName
+			shared
+			createdAt
+		}
+	}
+}
+`
+
+func (c *Client) CreateCustomView(ctx context.Context, input CustomViewCreateInput, interceptors ...clientv2.RequestInterceptor) (*CreateCustomView, error) {
+	vars := map[string]any{
+		"input": input,
+	}
+
+	var res CreateCustomView
+	if err := c.Client.Post(ctx, "CreateCustomView", CreateCustomViewDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const UpdateCustomViewDocument = `mutation UpdateCustomView ($id: String!, $input: CustomViewUpdateInput!) {
+	customViewUpdate(id: $id, input: $input) {
+		success
+		customView {
+			id
+			name
+			description
+			icon
+			color
+			filterData
+			modelName
+			shared
+			updatedAt
+		}
+	}
+}
+`
+
+func (c *Client) UpdateCustomView(ctx context.Context, id string, input CustomViewUpdateInput, interceptors ...clientv2.RequestInterceptor) (*UpdateCustomView, error) {
+	vars := map[string]any{
+		"id":    id,
+		"input": input,
+	}
+
+	var res UpdateCustomView
+	if err := c.Client.Post(ctx, "UpdateCustomView", UpdateCustomViewDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const DeleteCustomViewDocument = `mutation DeleteCustomView ($id: String!) {
+	customViewDelete(id: $id) {
+		success
+	}
+}
+`
+
+func (c *Client) DeleteCustomView(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*DeleteCustomView, error) {
+	vars := map[string]any{
+		"id": id,
+	}
+
+	var res DeleteCustomView
+	if err := c.Client.Post(ctx, "DeleteCustomView", DeleteCustomViewDocument, &res, vars, interceptors...); err != nil {
 		if c.Client.ParseDataWhenErrors {
 			return &res, err
 		}
@@ -14346,6 +15108,8 @@ var DocumentOperationNames = map[string]string{
 	GetCommentDocument:                     "GetComment",
 	ListCommentsDocument:                   "ListComments",
 	ListCommentsFilteredDocument:           "ListCommentsFiltered",
+	GetCustomViewDocument:                  "GetCustomView",
+	ListCustomViewsDocument:                "ListCustomViews",
 	GetCycleDocument:                       "GetCycle",
 	ListCyclesDocument:                     "ListCycles",
 	ListCyclesFilteredDocument:             "ListCyclesFiltered",
@@ -14375,6 +15139,9 @@ var DocumentOperationNames = map[string]string{
 	CreateCommentDocument:                  "CreateComment",
 	UpdateCommentDocument:                  "UpdateComment",
 	DeleteCommentDocument:                  "DeleteComment",
+	CreateCustomViewDocument:               "CreateCustomView",
+	UpdateCustomViewDocument:               "UpdateCustomView",
+	DeleteCustomViewDocument:               "DeleteCustomView",
 	CreateCycleDocument:                    "CreateCycle",
 	UpdateCycleDocument:                    "UpdateCycle",
 	ArchiveCycleDocument:                   "ArchiveCycle",

--- a/pkg/linear/client_custom_views.go
+++ b/pkg/linear/client_custom_views.go
@@ -1,0 +1,131 @@
+package linear
+
+import (
+	"context"
+
+	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
+)
+
+// CustomView retrieves a single custom view by ID.
+//
+// Returns:
+//   - CustomView with ID, Name, Description, Icon, Color, FilterData, ModelName, Shared, Creator, Owner, Team
+//   - error: Non-nil if custom view not found or query fails
+//
+// Permissions Required: Read
+//
+// Related: [CustomViews], [CustomViewCreate], [CustomViewUpdate]
+func (c *Client) CustomView(ctx context.Context, id string) (*intgraphql.GetCustomView_CustomView, error) {
+	resp, err := c.gqlClient.GetCustomView(ctx, id)
+	if err != nil {
+		return nil, wrapGraphQLError("custom view query", err)
+	}
+	return &resp.CustomView, nil
+}
+
+// CustomViews retrieves a paginated list of custom views.
+//
+// Parameters:
+//   - first: Number of custom views to return (nil = server default ~50)
+//   - after: Cursor for pagination (nil = start from beginning)
+//
+// Returns:
+//   - CustomViews.Nodes: Array of custom views (may be empty)
+//   - CustomViews.PageInfo.HasNextPage: true if more results available
+//   - CustomViews.PageInfo.EndCursor: Cursor for next page
+//   - error: Non-nil if query fails
+//
+// Permissions Required: Read
+//
+// Related: [CustomView], [CustomViewCreate]
+func (c *Client) CustomViews(ctx context.Context, first *int64, after *string) (*intgraphql.ListCustomViews_CustomViews, error) {
+	resp, err := c.gqlClient.ListCustomViews(ctx, first, after)
+	if err != nil {
+		return nil, wrapGraphQLError("custom views query", err)
+	}
+	return &resp.CustomViews, nil
+}
+
+// CustomViewCreate creates a new custom view.
+//
+// Required fields:
+//   - Name: Custom view name
+//
+// Optional fields:
+//   - Description: Custom view description
+//   - Icon: Custom view icon
+//   - Color: Icon color
+//   - FilterData: Issue filter as IssueFilter
+//   - Shared: Whether shared with organization
+//   - TeamID: Associated team UUID
+//
+// Returns:
+//   - Created custom view with ID, Name, and other fields
+//   - error: Non-nil if creation fails or Success is false
+//
+// Permissions Required: Write
+//
+// Related: [CustomView], [CustomViewUpdate], [CustomViewDelete]
+func (c *Client) CustomViewCreate(ctx context.Context, input intgraphql.CustomViewCreateInput) (*intgraphql.CreateCustomView_CustomViewCreate_CustomView, error) {
+	resp, err := c.gqlClient.CreateCustomView(ctx, input)
+	if err != nil {
+		return nil, wrapGraphQLError("CustomViewCreate", err)
+	}
+
+	if !resp.CustomViewCreate.Success {
+		return nil, errMutationFailed("CustomViewCreate")
+	}
+
+	return &resp.CustomViewCreate.CustomView, nil
+}
+
+// CustomViewUpdate updates an existing custom view.
+//
+// Parameters:
+//   - id: Custom view UUID to update (required)
+//   - input: Fields to update (all optional, nil = unchanged)
+//
+// Returns:
+//   - Updated custom view with new values
+//   - error: Non-nil if update fails or Success is false
+//
+// Permissions Required: Write
+//
+// Related: [CustomView], [CustomViewCreate], [CustomViewDelete]
+func (c *Client) CustomViewUpdate(ctx context.Context, id string, input intgraphql.CustomViewUpdateInput) (*intgraphql.UpdateCustomView_CustomViewUpdate_CustomView, error) {
+	resp, err := c.gqlClient.UpdateCustomView(ctx, id, input)
+	if err != nil {
+		return nil, wrapGraphQLError("CustomViewUpdate", err)
+	}
+
+	if !resp.CustomViewUpdate.Success {
+		return nil, errMutationFailed("CustomViewUpdate")
+	}
+
+	return &resp.CustomViewUpdate.CustomView, nil
+}
+
+// CustomViewDelete deletes a custom view by ID.
+//
+// Parameters:
+//   - id: Custom view UUID to delete (required)
+//
+// Returns:
+//   - nil: Custom view successfully deleted
+//   - error: Non-nil if delete fails or Success is false
+//
+// Permissions Required: Write
+//
+// Related: [CustomView], [CustomViewCreate]
+func (c *Client) CustomViewDelete(ctx context.Context, id string) error {
+	resp, err := c.gqlClient.DeleteCustomView(ctx, id)
+	if err != nil {
+		return wrapGraphQLError("CustomViewDelete", err)
+	}
+
+	if !resp.CustomViewDelete.Success {
+		return errMutationFailed("CustomViewDelete")
+	}
+
+	return nil
+}

--- a/queries/custom_views.graphql
+++ b/queries/custom_views.graphql
@@ -1,0 +1,58 @@
+query GetCustomView($id: String!) {
+  customView(id: $id) {
+    id
+    name
+    description
+    icon
+    color
+    filterData
+    projectFilterData
+    initiativeFilterData
+    modelName
+    shared
+    createdAt
+    updatedAt
+    creator {
+      id
+      name
+    }
+    owner {
+      id
+      name
+    }
+    team {
+      id
+      name
+      key
+    }
+  }
+}
+
+query ListCustomViews($first: Int, $after: String) {
+  customViews(first: $first, after: $after) {
+    nodes {
+      id
+      name
+      description
+      icon
+      color
+      modelName
+      shared
+      createdAt
+      updatedAt
+      creator {
+        id
+        name
+      }
+      team {
+        id
+        name
+        key
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/queries/mutations/custom_views.graphql
+++ b/queries/mutations/custom_views.graphql
@@ -1,0 +1,39 @@
+mutation CreateCustomView($input: CustomViewCreateInput!) {
+  customViewCreate(input: $input) {
+    success
+    customView {
+      id
+      name
+      description
+      icon
+      color
+      filterData
+      modelName
+      shared
+      createdAt
+    }
+  }
+}
+
+mutation UpdateCustomView($id: String!, $input: CustomViewUpdateInput!) {
+  customViewUpdate(id: $id, input: $input) {
+    success
+    customView {
+      id
+      name
+      description
+      icon
+      color
+      filterData
+      modelName
+      shared
+      updatedAt
+    }
+  }
+}
+
+mutation DeleteCustomView($id: String!) {
+  customViewDelete(id: $id) {
+    success
+  }
+}


### PR DESCRIPTION
## Summary
- CRUD for saved custom views: `list`, `get`, `create`, `update`, `delete`
- Supports `--name`, `--description`, `--icon`, `--color`, `--team`, `--shared`, `--filter-data` (JSON or @file)
- Alias: `cv` for `custom-view`

Closes #55

## Test plan
- [x] `go build ./...` passes
- [ ] Manual: `go-linear custom-view list`
- [ ] Manual: `go-linear cv create --name "My View" --team ENG`

🤖 Generated with [Claude Code](https://claude.com/claude-code)