### PR TITLE
feat(project): add label and relation CRUD commands

### DIFF
--- a/cmd/linear/commands/project/helpers_test.go
+++ b/cmd/linear/commands/project/helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
@@ -42,6 +43,56 @@ func mockServer(t *testing.T, handlers map[string]string) *httptest.Server {
 		}
 		_, _ = w.Write([]byte(`{"data":{}}`))
 	}))
+}
+
+// mockServerCapture returns a test server and a function that returns the
+// GraphQL variables from the most recent request. Used to assert that the
+// correct fields are sent to the API.
+func mockServerCapture(t *testing.T, handlers map[string]string) (*httptest.Server, func() map[string]any) {
+	t.Helper()
+	var mu sync.Mutex
+	var last map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		var reqBody struct {
+			Query         string         `json:"query"`
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			http.Error(w, "Bad request", http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		last = reqBody.Variables
+		mu.Unlock()
+
+		query := strings.ToLower(reqBody.Query)
+		opName := strings.ToLower(reqBody.OperationName)
+
+		for key, response := range handlers {
+			if strings.EqualFold(key, opName) {
+				_, _ = w.Write([]byte(response))
+				return
+			}
+		}
+		for key, response := range handlers {
+			if strings.Contains(query, strings.ToLower(key)) {
+				_, _ = w.Write([]byte(response))
+				return
+			}
+		}
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+
+	return server, func() map[string]any {
+		mu.Lock()
+		defer mu.Unlock()
+		return last
+	}
 }
 
 func testFactory(t *testing.T, serverURL string) cli.ClientFactory {

--- a/cmd/linear/commands/project/helpers_test.go
+++ b/cmd/linear/commands/project/helpers_test.go
@@ -333,6 +333,17 @@ const (
 			}
 		}
 	}`
+
+	mockProjectRelationsResponse = `{
+		"data": {
+			"projectRelations": {
+				"nodes": [
+					{"id": "prel-123", "type": "blocks"}
+				],
+				"pageInfo": {"hasNextPage": false}
+			}
+		}
+	}`
 )
 
 func defaultHandlers() map[string]string {
@@ -359,5 +370,6 @@ func defaultHandlers() map[string]string {
 		"ProjectRelationCreate":  mockProjectRelationCreateResponse,
 		"ProjectRelationUpdate":  mockProjectRelationUpdateResponse,
 		"ProjectRelationDelete":  mockProjectRelationDeleteResponse,
+		"ListProjectRelations":   mockProjectRelationsResponse,
 	}
 }

--- a/cmd/linear/commands/project/helpers_test.go
+++ b/cmd/linear/commands/project/helpers_test.go
@@ -270,6 +270,69 @@ const (
 			}
 		}
 	}`
+
+	mockProjectLabelsResponse = `{
+		"data": {
+			"projectLabels": {
+				"nodes": [
+					{"id": "plabel-123", "name": "Backend", "color": "#ff0000"}
+				],
+				"pageInfo": {"hasNextPage": false}
+			}
+		}
+	}`
+
+	mockProjectLabelCreateResponse = `{
+		"data": {
+			"projectLabelCreate": {
+				"success": true,
+				"projectLabel": {"id": "plabel-999", "name": "New Label", "color": "#00ff00"}
+			}
+		}
+	}`
+
+	mockProjectLabelUpdateResponse = `{
+		"data": {
+			"projectLabelUpdate": {
+				"success": true,
+				"projectLabel": {"id": "plabel-123", "name": "Updated Label"}
+			}
+		}
+	}`
+
+	mockProjectLabelDeleteResponse = `{
+		"data": {
+			"projectLabelDelete": {
+				"success": true
+			}
+		}
+	}`
+
+	mockProjectRelationCreateResponse = `{
+		"data": {
+			"projectRelationCreate": {
+				"success": true,
+				"projectRelation": {"id": "prel-999", "type": "blocks"}
+			}
+		}
+	}`
+
+	mockProjectRelationUpdateResponse = `{
+		"data": {
+			"projectRelationUpdate": {
+				"success": true,
+				"projectRelation": {"id": "prel-123", "type": "related"}
+			}
+		}
+	}`
+
+	mockProjectRelationDeleteResponse = `{
+		"data": {
+			"projectRelationDelete": {
+				"success": true
+			}
+		}
+	}`
 )
 
 func defaultHandlers() map[string]string {
@@ -289,5 +352,12 @@ func defaultHandlers() map[string]string {
 		"DeleteProjectUpdate":    mockProjectUpdateDeleteResponse,
 		"UnarchiveProject":       mockProjectUnarchiveResponse,
 		"ArchiveProject":         mockProjectArchiveResponse,
+		"ListProjectLabels":      mockProjectLabelsResponse,
+		"ProjectLabelCreate":     mockProjectLabelCreateResponse,
+		"ProjectLabelUpdate":     mockProjectLabelUpdateResponse,
+		"ProjectLabelDelete":     mockProjectLabelDeleteResponse,
+		"ProjectRelationCreate":  mockProjectRelationCreateResponse,
+		"ProjectRelationUpdate":  mockProjectRelationUpdateResponse,
+		"ProjectRelationDelete":  mockProjectRelationDeleteResponse,
 	}
 }

--- a/cmd/linear/commands/project/label_create.go
+++ b/cmd/linear/commands/project/label_create.go
@@ -35,11 +35,12 @@ Related: project_label-list, project_label-update, project_label-delete`,
 		},
 	}
 
-	_ = cmd.MarkFlagRequired("name")
 	cmd.Flags().String("name", "", "Label name (required)")
 	cmd.Flags().String("color", "", "Label color as hex string (e.g. #ff0000)")
 	cmd.Flags().String("description", "", "Label description")
 	cmd.Flags().String("parent-id", "", "Parent label ID for grouping")
+
+	_ = cmd.MarkFlagRequired("name")
 
 	return cmd
 }
@@ -53,15 +54,18 @@ func runLabelCreate(cmd *cobra.Command, client *linear.Client) error {
 		Name: name,
 	}
 
-	if color, _ := cmd.Flags().GetString("color"); color != "" {
+	if cmd.Flags().Changed("color") {
+		color, _ := cmd.Flags().GetString("color")
 		input.Color = &color
 	}
 
-	if desc, _ := cmd.Flags().GetString("description"); desc != "" {
+	if cmd.Flags().Changed("description") {
+		desc, _ := cmd.Flags().GetString("description")
 		input.Description = &desc
 	}
 
-	if parentID, _ := cmd.Flags().GetString("parent-id"); parentID != "" {
+	if cmd.Flags().Changed("parent-id") {
+		parentID, _ := cmd.Flags().GetString("parent-id")
 		input.ParentID = &parentID
 	}
 

--- a/cmd/linear/commands/project/label_create.go
+++ b/cmd/linear/commands/project/label_create.go
@@ -1,0 +1,74 @@
+package project
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewLabelCreateCommand creates the project label-create command.
+func NewLabelCreateCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "label-create",
+		Short: "Create a project label",
+		Long: `Create a new project label. Safe operation.
+
+Required: --name
+Optional: --color (hex color), --description, --parent-id (parent label UUID)
+
+Example: go-linear project label-create --name="Backend" --color="#ff0000"
+
+Related: project_label-list, project_label-update, project_label-delete`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runLabelCreate(cmd, client)
+		},
+	}
+
+	_ = cmd.MarkFlagRequired("name")
+	cmd.Flags().String("name", "", "Label name (required)")
+	cmd.Flags().String("color", "", "Label color as hex string (e.g. #ff0000)")
+	cmd.Flags().String("description", "", "Label description")
+	cmd.Flags().String("parent-id", "", "Parent label ID for grouping")
+
+	return cmd
+}
+
+func runLabelCreate(cmd *cobra.Command, client *linear.Client) error {
+	ctx := cmd.Context()
+
+	name, _ := cmd.Flags().GetString("name")
+
+	input := intgraphql.ProjectLabelCreateInput{
+		Name: name,
+	}
+
+	if color, _ := cmd.Flags().GetString("color"); color != "" {
+		input.Color = &color
+	}
+
+	if desc, _ := cmd.Flags().GetString("description"); desc != "" {
+		input.Description = &desc
+	}
+
+	if parentID, _ := cmd.Flags().GetString("parent-id"); parentID != "" {
+		input.ParentID = &parentID
+	}
+
+	result, err := client.ProjectLabelCreate(ctx, input)
+	if err != nil {
+		return fmt.Errorf("failed to create project label: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), result, true)
+}

--- a/cmd/linear/commands/project/label_delete.go
+++ b/cmd/linear/commands/project/label_delete.go
@@ -14,10 +14,12 @@ import (
 
 // NewLabelDeleteCommand creates the project label-delete command.
 func NewLabelDeleteCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	confirmFlags := &cli.ConfirmationFlags{}
+
 	cmd := &cobra.Command{
 		Use:   "label-delete <label-id>",
 		Short: "Delete a project label",
-		Long: `⚠️ Delete a project label. Cannot be undone. Prompts unless --yes.
+		Long: `Delete a project label. Cannot be undone. Prompts unless --yes.
 
 Example: go-linear project label-delete <uuid>
 
@@ -30,29 +32,25 @@ Related: project_label-list, project_label-create`,
 			}
 			defer client.Close()
 
-			return runLabelDelete(cmd, client, args[0])
+			return runLabelDelete(cmd, client, args[0], confirmFlags)
 		},
 	}
 
-	cmd.Flags().Bool("yes", false, "Skip confirmation prompt")
+	confirmFlags.Bind(cmd)
 
 	return cmd
 }
 
-func runLabelDelete(cmd *cobra.Command, client *linear.Client, labelID string) error {
+func runLabelDelete(cmd *cobra.Command, client *linear.Client, labelID string, confirmFlags *cli.ConfirmationFlags) error {
 	ctx := cmd.Context()
 
-	yes, _ := cmd.Flags().GetBool("yes")
-	if !yes {
-		fmt.Fprintf(cmd.OutOrStderr(), "⚠️  Are you sure you want to delete this project label? This cannot be undone.\n")
+	if !confirmFlags.Yes {
+		fmt.Fprintf(cmd.OutOrStderr(), "Delete project label %s? This cannot be undone.\n", labelID)
 		fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
-
 		reader := bufio.NewReader(os.Stdin)
 		response, _ := reader.ReadString('\n')
-		response = strings.TrimSpace(response)
-
-		if !strings.EqualFold(response, "yes") {
-			fmt.Fprintln(cmd.OutOrStderr(), "Canceled")
+		if !strings.EqualFold(strings.TrimSpace(response), "yes") {
+			fmt.Fprintln(cmd.OutOrStderr(), "Canceled.")
 			return nil
 		}
 	}
@@ -62,6 +60,6 @@ func runLabelDelete(cmd *cobra.Command, client *linear.Client, labelID string) e
 		return fmt.Errorf("failed to delete project label: %w", err)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "✓ Deleted project label\n")
+	fmt.Fprintf(cmd.OutOrStdout(), "Deleted project label\n")
 	return nil
 }

--- a/cmd/linear/commands/project/label_delete.go
+++ b/cmd/linear/commands/project/label_delete.go
@@ -1,0 +1,67 @@
+package project
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewLabelDeleteCommand creates the project label-delete command.
+func NewLabelDeleteCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "label-delete <label-id>",
+		Short: "Delete a project label",
+		Long: `⚠️ Delete a project label. Cannot be undone. Prompts unless --yes.
+
+Example: go-linear project label-delete <uuid>
+
+Related: project_label-list, project_label-create`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runLabelDelete(cmd, client, args[0])
+		},
+	}
+
+	cmd.Flags().Bool("yes", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func runLabelDelete(cmd *cobra.Command, client *linear.Client, labelID string) error {
+	ctx := cmd.Context()
+
+	yes, _ := cmd.Flags().GetBool("yes")
+	if !yes {
+		fmt.Fprintf(cmd.OutOrStderr(), "⚠️  Are you sure you want to delete this project label? This cannot be undone.\n")
+		fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
+
+		reader := bufio.NewReader(os.Stdin)
+		response, _ := reader.ReadString('\n')
+		response = strings.TrimSpace(response)
+
+		if !strings.EqualFold(response, "yes") {
+			fmt.Fprintln(cmd.OutOrStderr(), "Canceled")
+			return nil
+		}
+	}
+
+	err := client.ProjectLabelDelete(ctx, labelID)
+	if err != nil {
+		return fmt.Errorf("failed to delete project label: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "✓ Deleted project label\n")
+	return nil
+}

--- a/cmd/linear/commands/project/label_list.go
+++ b/cmd/linear/commands/project/label_list.go
@@ -12,6 +12,8 @@ import (
 
 // NewLabelListCommand creates the project label-list command.
 func NewLabelListCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	paginationFlags := &cli.PaginationFlags{}
+
 	cmd := &cobra.Command{
 		Use:   "label-list",
 		Short: "List project labels",
@@ -28,17 +30,19 @@ Related: project_label-create, project_label-update, project_label-delete`,
 			}
 			defer client.Close()
 
-			return runLabelList(cmd, client)
+			return runLabelList(cmd, client, paginationFlags)
 		},
 	}
+
+	paginationFlags.Bind(cmd, 250)
 
 	return cmd
 }
 
-func runLabelList(cmd *cobra.Command, client *linear.Client) error {
+func runLabelList(cmd *cobra.Command, client *linear.Client, paginationFlags *cli.PaginationFlags) error {
 	ctx := cmd.Context()
 
-	labels, err := client.ProjectLabels(ctx, nil, nil)
+	labels, err := client.ProjectLabels(ctx, paginationFlags.LimitPtr(), paginationFlags.AfterPtr())
 	if err != nil {
 		return fmt.Errorf("failed to list project labels: %w", err)
 	}

--- a/cmd/linear/commands/project/label_list.go
+++ b/cmd/linear/commands/project/label_list.go
@@ -1,0 +1,47 @@
+package project
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewLabelListCommand creates the project label-list command.
+func NewLabelListCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "label-list",
+		Short: "List project labels",
+		Long: `List all project labels in the organization.
+
+Example: go-linear project label-list
+
+Related: project_label-create, project_label-update, project_label-delete`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runLabelList(cmd, client)
+		},
+	}
+
+	return cmd
+}
+
+func runLabelList(cmd *cobra.Command, client *linear.Client) error {
+	ctx := cmd.Context()
+
+	labels, err := client.ProjectLabels(ctx, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to list project labels: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), labels.Nodes, true)
+}

--- a/cmd/linear/commands/project/label_relation_test.go
+++ b/cmd/linear/commands/project/label_relation_test.go
@@ -56,6 +56,20 @@ func TestRunLabelList(t *testing.T) {
 	}
 }
 
+func TestRunLabelListPagination(t *testing.T) {
+	server := mockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testFactory(t, server.URL)
+
+	cmd := NewLabelListCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--limit=10"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() with --limit error = %v", err)
+	}
+}
+
 func TestRunLabelUpdate(t *testing.T) {
 	server := mockServer(t, defaultHandlers())
 	defer server.Close()
@@ -101,6 +115,110 @@ func TestRunRelationCreate(t *testing.T) {
 	})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestRunRelationCreateInvalidType(t *testing.T) {
+	server := mockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testFactory(t, server.URL)
+
+	cmd := NewRelationCreateCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--project=00000000-0000-0000-0000-000000000001",
+		"--related-project=00000000-0000-0000-0000-000000000002",
+		"--type=depends_on",
+		"--anchor-type=project",
+		"--related-anchor-type=project",
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("Execute() expected error for invalid --type, got nil")
+	}
+}
+
+func TestRunRelationCreateInvalidAnchorType(t *testing.T) {
+	server := mockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testFactory(t, server.URL)
+
+	cmd := NewRelationCreateCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--project=00000000-0000-0000-0000-000000000001",
+		"--related-project=00000000-0000-0000-0000-000000000002",
+		"--type=blocks",
+		"--anchor-type=invalid",
+		"--related-anchor-type=project",
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("Execute() expected error for invalid --anchor-type, got nil")
+	}
+}
+
+func TestRunRelationList(t *testing.T) {
+	server := mockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testFactory(t, server.URL)
+
+	cmd := NewRelationListCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var result any
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Output should be valid JSON: %v", err)
+	}
+}
+
+func TestRunRelationListPagination(t *testing.T) {
+	server := mockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testFactory(t, server.URL)
+
+	cmd := NewRelationListCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--limit=10"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() with --limit error = %v", err)
+	}
+}
+
+func TestRunRelationUpdate(t *testing.T) {
+	server := mockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testFactory(t, server.URL)
+
+	cmd := NewRelationUpdateCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"prel-123", "--type=related"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestRunRelationUpdateInvalidType(t *testing.T) {
+	server := mockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testFactory(t, server.URL)
+
+	cmd := NewRelationUpdateCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"prel-123", "--type=depends_on"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("Execute() expected error for invalid --type, got nil")
 	}
 }
 

--- a/cmd/linear/commands/project/label_relation_test.go
+++ b/cmd/linear/commands/project/label_relation_test.go
@@ -207,6 +207,36 @@ func TestRunRelationUpdate(t *testing.T) {
 	}
 }
 
+func TestRunLabelUpdateZeroValuePropagates(t *testing.T) {
+	server, lastVars := mockServerCapture(t, defaultHandlers())
+	defer server.Close()
+	factory := testFactory(t, server.URL)
+
+	cmd := NewLabelUpdateCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"plabel-123", "--name="})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	vars := lastVars()
+	if vars == nil {
+		t.Fatal("no variables captured")
+	}
+	input, ok := vars["input"].(map[string]any)
+	if !ok {
+		t.Fatalf("variables[input] type = %T, want map", vars["input"])
+	}
+	name, ok := input["name"]
+	if !ok {
+		t.Error("input.name missing: --name= should propagate empty string, not be dropped")
+	}
+	if name != "" {
+		t.Errorf("input.name = %q, want empty string", name)
+	}
+}
+
 func TestRunRelationUpdateInvalidType(t *testing.T) {
 	server := mockServer(t, defaultHandlers())
 	defer server.Close()

--- a/cmd/linear/commands/project/label_relation_test.go
+++ b/cmd/linear/commands/project/label_relation_test.go
@@ -1,0 +1,119 @@
+package project
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestNewLabelCreateCommand(t *testing.T) {
+	server := mockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testFactory(t, server.URL)
+
+	cmd := NewLabelCreateCommand(factory)
+	if !strings.HasPrefix(cmd.Use, "label-create") {
+		t.Errorf("Use = %q, want prefix label-create", cmd.Use)
+	}
+}
+
+func TestRunLabelCreate(t *testing.T) {
+	server := mockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testFactory(t, server.URL)
+
+	cmd := NewLabelCreateCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--name=Backend", "--color=#ff0000"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Output should be valid JSON: %v", err)
+	}
+}
+
+func TestRunLabelList(t *testing.T) {
+	server := mockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testFactory(t, server.URL)
+
+	cmd := NewLabelListCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var result any
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Output should be valid JSON: %v", err)
+	}
+}
+
+func TestRunLabelUpdate(t *testing.T) {
+	server := mockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testFactory(t, server.URL)
+
+	cmd := NewLabelUpdateCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"plabel-123", "--name=Updated"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestRunLabelDelete(t *testing.T) {
+	server := mockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testFactory(t, server.URL)
+
+	cmd := NewLabelDeleteCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"plabel-123", "--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestRunRelationCreate(t *testing.T) {
+	server := mockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testFactory(t, server.URL)
+
+	cmd := NewRelationCreateCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{
+		"--project=00000000-0000-0000-0000-000000000001",
+		"--related-project=00000000-0000-0000-0000-000000000002",
+		"--type=blocks",
+		"--anchor-type=project",
+		"--related-anchor-type=project",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestRunRelationDelete(t *testing.T) {
+	server := mockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testFactory(t, server.URL)
+
+	cmd := NewRelationDeleteCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"prel-123", "--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}

--- a/cmd/linear/commands/project/label_update.go
+++ b/cmd/linear/commands/project/label_update.go
@@ -1,0 +1,73 @@
+package project
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewLabelUpdateCommand creates the project label-update command.
+func NewLabelUpdateCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "label-update <label-id>",
+		Short: "Update a project label",
+		Long: `Update a project label. Modifies existing data.
+
+Fields: --name, --color, --description, --parent-id
+
+Example: go-linear project label-update <uuid> --name="Infrastructure" --color="#00ff00"
+
+Related: project_label-create, project_label-list, project_label-delete`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runLabelUpdate(cmd, client, args[0])
+		},
+	}
+
+	cmd.Flags().String("name", "", "New label name")
+	cmd.Flags().String("color", "", "New label color as hex string")
+	cmd.Flags().String("description", "", "New label description")
+	cmd.Flags().String("parent-id", "", "New parent label ID")
+
+	return cmd
+}
+
+func runLabelUpdate(cmd *cobra.Command, client *linear.Client, labelID string) error {
+	ctx := cmd.Context()
+
+	input := intgraphql.ProjectLabelUpdateInput{}
+
+	if name, _ := cmd.Flags().GetString("name"); name != "" {
+		input.Name = &name
+	}
+
+	if color, _ := cmd.Flags().GetString("color"); color != "" {
+		input.Color = &color
+	}
+
+	if desc, _ := cmd.Flags().GetString("description"); desc != "" {
+		input.Description = &desc
+	}
+
+	if parentID, _ := cmd.Flags().GetString("parent-id"); parentID != "" {
+		input.ParentID = &parentID
+	}
+
+	result, err := client.ProjectLabelUpdate(ctx, labelID, input)
+	if err != nil {
+		return fmt.Errorf("failed to update project label: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), result, true)
+}

--- a/cmd/linear/commands/project/label_update.go
+++ b/cmd/linear/commands/project/label_update.go
@@ -48,19 +48,23 @@ func runLabelUpdate(cmd *cobra.Command, client *linear.Client, labelID string) e
 
 	input := intgraphql.ProjectLabelUpdateInput{}
 
-	if name, _ := cmd.Flags().GetString("name"); name != "" {
+	if cmd.Flags().Changed("name") {
+		name, _ := cmd.Flags().GetString("name")
 		input.Name = &name
 	}
 
-	if color, _ := cmd.Flags().GetString("color"); color != "" {
+	if cmd.Flags().Changed("color") {
+		color, _ := cmd.Flags().GetString("color")
 		input.Color = &color
 	}
 
-	if desc, _ := cmd.Flags().GetString("description"); desc != "" {
+	if cmd.Flags().Changed("description") {
+		desc, _ := cmd.Flags().GetString("description")
 		input.Description = &desc
 	}
 
-	if parentID, _ := cmd.Flags().GetString("parent-id"); parentID != "" {
+	if cmd.Flags().Changed("parent-id") {
+		parentID, _ := cmd.Flags().GetString("parent-id")
 		input.ParentID = &parentID
 	}
 

--- a/cmd/linear/commands/project/project.go
+++ b/cmd/linear/commands/project/project.go
@@ -34,6 +34,14 @@ func NewProjectCommand(clientFactory cli.ClientFactory) *cobra.Command {
 	cmd.AddCommand(NewStatusUpdateListCommand(clientFactory))
 	cmd.AddCommand(NewStatusUpdateGetCommand(clientFactory))
 	cmd.AddCommand(NewStatusUpdateDeleteCommand(clientFactory))
+	cmd.AddCommand(NewLabelListCommand(clientFactory))
+	cmd.AddCommand(NewLabelCreateCommand(clientFactory))
+	cmd.AddCommand(NewLabelUpdateCommand(clientFactory))
+	cmd.AddCommand(NewLabelDeleteCommand(clientFactory))
+	cmd.AddCommand(NewRelationListCommand(clientFactory))
+	cmd.AddCommand(NewRelationCreateCommand(clientFactory))
+	cmd.AddCommand(NewRelationUpdateCommand(clientFactory))
+	cmd.AddCommand(NewRelationDeleteCommand(clientFactory))
 
 	return cmd
 }

--- a/cmd/linear/commands/project/relation_create.go
+++ b/cmd/linear/commands/project/relation_create.go
@@ -62,6 +62,9 @@ func runRelationCreate(cmd *cobra.Command, client *linear.Client) error {
 	ctx := cmd.Context()
 	res := resolver.New(client)
 
+	validRelationTypes := map[string]bool{"blocks": true, "dependsOn": true, "related": true}
+	validAnchorTypes := map[string]bool{"project": true, "milestone": true}
+
 	projectName, _ := cmd.Flags().GetString("project")
 	projectID, err := res.ResolveProject(ctx, projectName)
 	if err != nil {
@@ -97,11 +100,13 @@ func runRelationCreate(cmd *cobra.Command, client *linear.Client) error {
 		RelatedAnchorType: relatedAnchorType,
 	}
 
-	if milestoneID, _ := cmd.Flags().GetString("project-milestone"); milestoneID != "" {
+	if cmd.Flags().Changed("project-milestone") {
+		milestoneID, _ := cmd.Flags().GetString("project-milestone")
 		input.ProjectMilestoneID = &milestoneID
 	}
 
-	if relMilestoneID, _ := cmd.Flags().GetString("related-project-milestone"); relMilestoneID != "" {
+	if cmd.Flags().Changed("related-project-milestone") {
+		relMilestoneID, _ := cmd.Flags().GetString("related-project-milestone")
 		input.RelatedProjectMilestoneID = &relMilestoneID
 	}
 

--- a/cmd/linear/commands/project/relation_create.go
+++ b/cmd/linear/commands/project/relation_create.go
@@ -1,0 +1,100 @@
+package project
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/resolver"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewRelationCreateCommand creates the project relation-create command.
+func NewRelationCreateCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "relation-create",
+		Short: "Create a project relation",
+		Long: `Create a relationship between two projects. Safe operation.
+
+Required: --project, --related-project, --type, --anchor-type, --related-anchor-type
+Optional: --project-milestone, --related-project-milestone
+
+Relation types: blocks, dependsOn, related
+Anchor types: milestone, project
+
+Example: go-linear project relation-create --project=<uuid> --related-project=<uuid> --type=blocks --anchor-type=project --related-anchor-type=project
+
+Related: project_relation-update, project_relation-delete, project_relation-list`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runRelationCreate(cmd, client)
+		},
+	}
+
+	_ = cmd.MarkFlagRequired("project")
+	_ = cmd.MarkFlagRequired("related-project")
+	_ = cmd.MarkFlagRequired("type")
+	_ = cmd.MarkFlagRequired("anchor-type")
+	_ = cmd.MarkFlagRequired("related-anchor-type")
+	cmd.Flags().String("project", "", "Project name or ID (required)")
+	cmd.Flags().String("related-project", "", "Related project name or ID (required)")
+	cmd.Flags().String("type", "", "Relation type: blocks, dependsOn, related (required)")
+	cmd.Flags().String("anchor-type", "", "Anchor type for project end: project, milestone (required)")
+	cmd.Flags().String("related-anchor-type", "", "Anchor type for related project end: project, milestone (required)")
+	cmd.Flags().String("project-milestone", "", "Project milestone ID (optional)")
+	cmd.Flags().String("related-project-milestone", "", "Related project milestone ID (optional)")
+
+	return cmd
+}
+
+func runRelationCreate(cmd *cobra.Command, client *linear.Client) error {
+	ctx := cmd.Context()
+	res := resolver.New(client)
+
+	projectName, _ := cmd.Flags().GetString("project")
+	projectID, err := res.ResolveProject(ctx, projectName)
+	if err != nil {
+		return fmt.Errorf("failed to resolve project: %w", err)
+	}
+
+	relatedProjectName, _ := cmd.Flags().GetString("related-project")
+	relatedProjectID, err := res.ResolveProject(ctx, relatedProjectName)
+	if err != nil {
+		return fmt.Errorf("failed to resolve related project: %w", err)
+	}
+
+	relationType, _ := cmd.Flags().GetString("type")
+	anchorType, _ := cmd.Flags().GetString("anchor-type")
+	relatedAnchorType, _ := cmd.Flags().GetString("related-anchor-type")
+
+	input := intgraphql.ProjectRelationCreateInput{
+		ProjectID:         projectID,
+		RelatedProjectID:  relatedProjectID,
+		Type:              relationType,
+		AnchorType:        anchorType,
+		RelatedAnchorType: relatedAnchorType,
+	}
+
+	if milestoneID, _ := cmd.Flags().GetString("project-milestone"); milestoneID != "" {
+		input.ProjectMilestoneID = &milestoneID
+	}
+
+	if relMilestoneID, _ := cmd.Flags().GetString("related-project-milestone"); relMilestoneID != "" {
+		input.RelatedProjectMilestoneID = &relMilestoneID
+	}
+
+	result, err := client.ProjectRelationCreate(ctx, input)
+	if err != nil {
+		return fmt.Errorf("failed to create project relation: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), result, true)
+}

--- a/cmd/linear/commands/project/relation_create.go
+++ b/cmd/linear/commands/project/relation_create.go
@@ -25,6 +25,8 @@ Optional: --project-milestone, --related-project-milestone
 Relation types: blocks, dependsOn, related
 Anchor types: milestone, project
 
+Note: Linear automatically creates the inverse relation (e.g. blocks A→B creates a blockedBy view from B).
+
 Example: go-linear project relation-create --project=<uuid> --related-project=<uuid> --type=blocks --anchor-type=project --related-anchor-type=project
 
 Related: project_relation-update, project_relation-delete, project_relation-list`,
@@ -39,11 +41,6 @@ Related: project_relation-update, project_relation-delete, project_relation-list
 		},
 	}
 
-	_ = cmd.MarkFlagRequired("project")
-	_ = cmd.MarkFlagRequired("related-project")
-	_ = cmd.MarkFlagRequired("type")
-	_ = cmd.MarkFlagRequired("anchor-type")
-	_ = cmd.MarkFlagRequired("related-anchor-type")
 	cmd.Flags().String("project", "", "Project name or ID (required)")
 	cmd.Flags().String("related-project", "", "Related project name or ID (required)")
 	cmd.Flags().String("type", "", "Relation type: blocks, dependsOn, related (required)")
@@ -51,6 +48,12 @@ Related: project_relation-update, project_relation-delete, project_relation-list
 	cmd.Flags().String("related-anchor-type", "", "Anchor type for related project end: project, milestone (required)")
 	cmd.Flags().String("project-milestone", "", "Project milestone ID (optional)")
 	cmd.Flags().String("related-project-milestone", "", "Related project milestone ID (optional)")
+
+	_ = cmd.MarkFlagRequired("project")
+	_ = cmd.MarkFlagRequired("related-project")
+	_ = cmd.MarkFlagRequired("type")
+	_ = cmd.MarkFlagRequired("anchor-type")
+	_ = cmd.MarkFlagRequired("related-anchor-type")
 
 	return cmd
 }
@@ -72,8 +75,19 @@ func runRelationCreate(cmd *cobra.Command, client *linear.Client) error {
 	}
 
 	relationType, _ := cmd.Flags().GetString("type")
+	if !validRelationTypes[relationType] {
+		return fmt.Errorf("invalid --type %q: must be one of blocks, dependsOn, related", relationType)
+	}
+
 	anchorType, _ := cmd.Flags().GetString("anchor-type")
+	if !validAnchorTypes[anchorType] {
+		return fmt.Errorf("invalid --anchor-type %q: must be one of project, milestone", anchorType)
+	}
+
 	relatedAnchorType, _ := cmd.Flags().GetString("related-anchor-type")
+	if !validAnchorTypes[relatedAnchorType] {
+		return fmt.Errorf("invalid --related-anchor-type %q: must be one of project, milestone", relatedAnchorType)
+	}
 
 	input := intgraphql.ProjectRelationCreateInput{
 		ProjectID:         projectID,

--- a/cmd/linear/commands/project/relation_delete.go
+++ b/cmd/linear/commands/project/relation_delete.go
@@ -14,10 +14,12 @@ import (
 
 // NewRelationDeleteCommand creates the project relation-delete command.
 func NewRelationDeleteCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	confirmFlags := &cli.ConfirmationFlags{}
+
 	cmd := &cobra.Command{
 		Use:   "relation-delete <relation-id>",
 		Short: "Delete a project relation",
-		Long: `⚠️ Delete a project relation. Cannot be undone. Prompts unless --yes.
+		Long: `Delete a project relation. Cannot be undone. Prompts unless --yes.
 
 Example: go-linear project relation-delete <uuid>
 
@@ -30,29 +32,25 @@ Related: project_relation-list, project_relation-create`,
 			}
 			defer client.Close()
 
-			return runRelationDelete(cmd, client, args[0])
+			return runRelationDelete(cmd, client, args[0], confirmFlags)
 		},
 	}
 
-	cmd.Flags().Bool("yes", false, "Skip confirmation prompt")
+	confirmFlags.Bind(cmd)
 
 	return cmd
 }
 
-func runRelationDelete(cmd *cobra.Command, client *linear.Client, relationID string) error {
+func runRelationDelete(cmd *cobra.Command, client *linear.Client, relationID string, confirmFlags *cli.ConfirmationFlags) error {
 	ctx := cmd.Context()
 
-	yes, _ := cmd.Flags().GetBool("yes")
-	if !yes {
-		fmt.Fprintf(cmd.OutOrStderr(), "⚠️  Are you sure you want to delete this project relation? This cannot be undone.\n")
+	if !confirmFlags.Yes {
+		fmt.Fprintf(cmd.OutOrStderr(), "Delete project relation %s? This cannot be undone.\n", relationID)
 		fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
-
 		reader := bufio.NewReader(os.Stdin)
 		response, _ := reader.ReadString('\n')
-		response = strings.TrimSpace(response)
-
-		if !strings.EqualFold(response, "yes") {
-			fmt.Fprintln(cmd.OutOrStderr(), "Canceled")
+		if !strings.EqualFold(strings.TrimSpace(response), "yes") {
+			fmt.Fprintln(cmd.OutOrStderr(), "Canceled.")
 			return nil
 		}
 	}
@@ -62,6 +60,6 @@ func runRelationDelete(cmd *cobra.Command, client *linear.Client, relationID str
 		return fmt.Errorf("failed to delete project relation: %w", err)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "✓ Deleted project relation\n")
+	fmt.Fprintf(cmd.OutOrStdout(), "Deleted project relation\n")
 	return nil
 }

--- a/cmd/linear/commands/project/relation_delete.go
+++ b/cmd/linear/commands/project/relation_delete.go
@@ -1,0 +1,67 @@
+package project
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewRelationDeleteCommand creates the project relation-delete command.
+func NewRelationDeleteCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "relation-delete <relation-id>",
+		Short: "Delete a project relation",
+		Long: `⚠️ Delete a project relation. Cannot be undone. Prompts unless --yes.
+
+Example: go-linear project relation-delete <uuid>
+
+Related: project_relation-list, project_relation-create`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runRelationDelete(cmd, client, args[0])
+		},
+	}
+
+	cmd.Flags().Bool("yes", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func runRelationDelete(cmd *cobra.Command, client *linear.Client, relationID string) error {
+	ctx := cmd.Context()
+
+	yes, _ := cmd.Flags().GetBool("yes")
+	if !yes {
+		fmt.Fprintf(cmd.OutOrStderr(), "⚠️  Are you sure you want to delete this project relation? This cannot be undone.\n")
+		fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
+
+		reader := bufio.NewReader(os.Stdin)
+		response, _ := reader.ReadString('\n')
+		response = strings.TrimSpace(response)
+
+		if !strings.EqualFold(response, "yes") {
+			fmt.Fprintln(cmd.OutOrStderr(), "Canceled")
+			return nil
+		}
+	}
+
+	err := client.ProjectRelationDelete(ctx, relationID)
+	if err != nil {
+		return fmt.Errorf("failed to delete project relation: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "✓ Deleted project relation\n")
+	return nil
+}

--- a/cmd/linear/commands/project/relation_list.go
+++ b/cmd/linear/commands/project/relation_list.go
@@ -12,6 +12,8 @@ import (
 
 // NewRelationListCommand creates the project relation-list command.
 func NewRelationListCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	paginationFlags := &cli.PaginationFlags{}
+
 	cmd := &cobra.Command{
 		Use:   "relation-list",
 		Short: "List project relations",
@@ -28,17 +30,19 @@ Related: project_relation-create, project_relation-update, project_relation-dele
 			}
 			defer client.Close()
 
-			return runRelationList(cmd, client)
+			return runRelationList(cmd, client, paginationFlags)
 		},
 	}
+
+	paginationFlags.Bind(cmd, 250)
 
 	return cmd
 }
 
-func runRelationList(cmd *cobra.Command, client *linear.Client) error {
+func runRelationList(cmd *cobra.Command, client *linear.Client, paginationFlags *cli.PaginationFlags) error {
 	ctx := cmd.Context()
 
-	relations, err := client.ProjectRelations(ctx, nil, nil)
+	relations, err := client.ProjectRelations(ctx, paginationFlags.LimitPtr(), paginationFlags.AfterPtr())
 	if err != nil {
 		return fmt.Errorf("failed to list project relations: %w", err)
 	}

--- a/cmd/linear/commands/project/relation_list.go
+++ b/cmd/linear/commands/project/relation_list.go
@@ -1,0 +1,47 @@
+package project
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewRelationListCommand creates the project relation-list command.
+func NewRelationListCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "relation-list",
+		Short: "List project relations",
+		Long: `List all project relations in the organization.
+
+Example: go-linear project relation-list
+
+Related: project_relation-create, project_relation-update, project_relation-delete`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runRelationList(cmd, client)
+		},
+	}
+
+	return cmd
+}
+
+func runRelationList(cmd *cobra.Command, client *linear.Client) error {
+	ctx := cmd.Context()
+
+	relations, err := client.ProjectRelations(ctx, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to list project relations: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), relations.Nodes, true)
+}

--- a/cmd/linear/commands/project/relation_update.go
+++ b/cmd/linear/commands/project/relation_update.go
@@ -1,0 +1,68 @@
+package project
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewRelationUpdateCommand creates the project relation-update command.
+func NewRelationUpdateCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "relation-update <relation-id>",
+		Short: "Update a project relation",
+		Long: `Update a project relation. Modifies existing data.
+
+Fields: --type, --anchor-type, --related-anchor-type
+
+Example: go-linear project relation-update <uuid> --type=dependsOn
+
+Related: project_relation-create, project_relation-delete, project_relation-list`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runRelationUpdate(cmd, client, args[0])
+		},
+	}
+
+	cmd.Flags().String("type", "", "New relation type: blocks, dependsOn, related")
+	cmd.Flags().String("anchor-type", "", "New anchor type for project end")
+	cmd.Flags().String("related-anchor-type", "", "New anchor type for related project end")
+
+	return cmd
+}
+
+func runRelationUpdate(cmd *cobra.Command, client *linear.Client, relationID string) error {
+	ctx := cmd.Context()
+
+	input := intgraphql.ProjectRelationUpdateInput{}
+
+	if relationType, _ := cmd.Flags().GetString("type"); relationType != "" {
+		input.Type = &relationType
+	}
+
+	if anchorType, _ := cmd.Flags().GetString("anchor-type"); anchorType != "" {
+		input.AnchorType = &anchorType
+	}
+
+	if relatedAnchorType, _ := cmd.Flags().GetString("related-anchor-type"); relatedAnchorType != "" {
+		input.RelatedAnchorType = &relatedAnchorType
+	}
+
+	result, err := client.ProjectRelationUpdate(ctx, relationID, input)
+	if err != nil {
+		return fmt.Errorf("failed to update project relation: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), result, true)
+}

--- a/cmd/linear/commands/project/relation_update.go
+++ b/cmd/linear/commands/project/relation_update.go
@@ -49,11 +49,11 @@ Related: project_relation-create, project_relation-delete, project_relation-list
 	return cmd
 }
 
-var validRelationTypes = map[string]bool{"blocks": true, "dependsOn": true, "related": true}
-var validAnchorTypes = map[string]bool{"project": true, "milestone": true}
-
 func runRelationUpdate(cmd *cobra.Command, client *linear.Client, relationID string) error {
 	ctx := cmd.Context()
+
+	validRelationTypes := map[string]bool{"blocks": true, "dependsOn": true, "related": true}
+	validAnchorTypes := map[string]bool{"project": true, "milestone": true}
 
 	input := intgraphql.ProjectRelationUpdateInput{}
 

--- a/cmd/linear/commands/project/relation_update.go
+++ b/cmd/linear/commands/project/relation_update.go
@@ -18,7 +18,10 @@ func NewRelationUpdateCommand(clientFactory cli.ClientFactory) *cobra.Command {
 		Short: "Update a project relation",
 		Long: `Update a project relation. Modifies existing data.
 
-Fields: --type, --anchor-type, --related-anchor-type
+Fields: --type, --anchor-type, --related-anchor-type, --project-id, --related-project-id, --project-milestone-id, --related-project-milestone-id
+
+Relation types: blocks, dependsOn, related
+Anchor types: project, milestone
 
 Example: go-linear project relation-update <uuid> --type=dependsOn
 
@@ -36,27 +39,66 @@ Related: project_relation-create, project_relation-delete, project_relation-list
 	}
 
 	cmd.Flags().String("type", "", "New relation type: blocks, dependsOn, related")
-	cmd.Flags().String("anchor-type", "", "New anchor type for project end")
-	cmd.Flags().String("related-anchor-type", "", "New anchor type for related project end")
+	cmd.Flags().String("anchor-type", "", "New anchor type for project end: project, milestone")
+	cmd.Flags().String("related-anchor-type", "", "New anchor type for related project end: project, milestone")
+	cmd.Flags().String("project-id", "", "New project ID")
+	cmd.Flags().String("related-project-id", "", "New related project ID")
+	cmd.Flags().String("project-milestone-id", "", "New project milestone ID")
+	cmd.Flags().String("related-project-milestone-id", "", "New related project milestone ID")
 
 	return cmd
 }
+
+var validRelationTypes = map[string]bool{"blocks": true, "dependsOn": true, "related": true}
+var validAnchorTypes = map[string]bool{"project": true, "milestone": true}
 
 func runRelationUpdate(cmd *cobra.Command, client *linear.Client, relationID string) error {
 	ctx := cmd.Context()
 
 	input := intgraphql.ProjectRelationUpdateInput{}
 
-	if relationType, _ := cmd.Flags().GetString("type"); relationType != "" {
+	if cmd.Flags().Changed("type") {
+		relationType, _ := cmd.Flags().GetString("type")
+		if !validRelationTypes[relationType] {
+			return fmt.Errorf("invalid --type %q: must be one of blocks, dependsOn, related", relationType)
+		}
 		input.Type = &relationType
 	}
 
-	if anchorType, _ := cmd.Flags().GetString("anchor-type"); anchorType != "" {
+	if cmd.Flags().Changed("anchor-type") {
+		anchorType, _ := cmd.Flags().GetString("anchor-type")
+		if !validAnchorTypes[anchorType] {
+			return fmt.Errorf("invalid --anchor-type %q: must be one of project, milestone", anchorType)
+		}
 		input.AnchorType = &anchorType
 	}
 
-	if relatedAnchorType, _ := cmd.Flags().GetString("related-anchor-type"); relatedAnchorType != "" {
+	if cmd.Flags().Changed("related-anchor-type") {
+		relatedAnchorType, _ := cmd.Flags().GetString("related-anchor-type")
+		if !validAnchorTypes[relatedAnchorType] {
+			return fmt.Errorf("invalid --related-anchor-type %q: must be one of project, milestone", relatedAnchorType)
+		}
 		input.RelatedAnchorType = &relatedAnchorType
+	}
+
+	if cmd.Flags().Changed("project-id") {
+		projectID, _ := cmd.Flags().GetString("project-id")
+		input.ProjectID = &projectID
+	}
+
+	if cmd.Flags().Changed("related-project-id") {
+		relatedProjectID, _ := cmd.Flags().GetString("related-project-id")
+		input.RelatedProjectID = &relatedProjectID
+	}
+
+	if cmd.Flags().Changed("project-milestone-id") {
+		projectMilestoneID, _ := cmd.Flags().GetString("project-milestone-id")
+		input.ProjectMilestoneID = &projectMilestoneID
+	}
+
+	if cmd.Flags().Changed("related-project-milestone-id") {
+		relatedProjectMilestoneID, _ := cmd.Flags().GetString("related-project-milestone-id")
+		input.RelatedProjectMilestoneID = &relatedProjectMilestoneID
 	}
 
 	result, err := client.ProjectRelationUpdate(ctx, relationID, input)

--- a/internal/graphql/client.go
+++ b/internal/graphql/client.go
@@ -92,6 +92,12 @@ type LinearGraphQLClient interface {
 	DeleteProject(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*DeleteProject, error)
 	ArchiveProject(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*ArchiveProject, error)
 	UnarchiveProject(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*UnarchiveProject, error)
+	ProjectLabelCreate(ctx context.Context, input ProjectLabelCreateInput, interceptors ...clientv2.RequestInterceptor) (*ProjectLabelCreate, error)
+	ProjectLabelUpdate(ctx context.Context, id string, input ProjectLabelUpdateInput, interceptors ...clientv2.RequestInterceptor) (*ProjectLabelUpdate, error)
+	ProjectLabelDelete(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*ProjectLabelDelete, error)
+	ProjectRelationCreate(ctx context.Context, input ProjectRelationCreateInput, interceptors ...clientv2.RequestInterceptor) (*ProjectRelationCreate, error)
+	ProjectRelationUpdate(ctx context.Context, id string, input ProjectRelationUpdateInput, interceptors ...clientv2.RequestInterceptor) (*ProjectRelationUpdate, error)
+	ProjectRelationDelete(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*ProjectRelationDelete, error)
 	ReactionCreate(ctx context.Context, input ReactionCreateInput, interceptors ...clientv2.RequestInterceptor) (*ReactionCreate, error)
 	ReactionDelete(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*ReactionDelete, error)
 	AddTeamMember(ctx context.Context, input TeamMembershipCreateInput, interceptors ...clientv2.RequestInterceptor) (*AddTeamMember, error)
@@ -109,6 +115,9 @@ type LinearGraphQLClient interface {
 	GetProject(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*GetProject, error)
 	ListProjects(ctx context.Context, first *int64, after *string, interceptors ...clientv2.RequestInterceptor) (*ListProjects, error)
 	ListProjectsFiltered(ctx context.Context, first *int64, after *string, filter *ProjectFilter, interceptors ...clientv2.RequestInterceptor) (*ListProjectsFiltered, error)
+	ListProjectLabels(ctx context.Context, first *int64, after *string, interceptors ...clientv2.RequestInterceptor) (*ListProjectLabels, error)
+	GetProjectLabel(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*GetProjectLabel, error)
+	ListProjectRelations(ctx context.Context, first *int64, after *string, interceptors ...clientv2.RequestInterceptor) (*ListProjectRelations, error)
 	GetRoadmap(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*GetRoadmap, error)
 	ListRoadmaps(ctx context.Context, first *int64, after *string, interceptors ...clientv2.RequestInterceptor) (*ListRoadmaps, error)
 	SearchIssues(ctx context.Context, term string, first *int64, after *string, filter *IssueFilter, includeArchived *bool, interceptors ...clientv2.RequestInterceptor) (*SearchIssues, error)
@@ -5979,6 +5988,292 @@ func (t *UnarchiveProject_ProjectUnarchive) GetSuccess() bool {
 	return t.Success
 }
 
+type ProjectLabelCreate_ProjectLabelCreate_ProjectLabel struct {
+	Color       string  "json:\"color\" graphql:\"color\""
+	Description *string "json:\"description,omitempty\" graphql:\"description\""
+	ID          string  "json:\"id\" graphql:\"id\""
+	IsGroup     bool    "json:\"isGroup\" graphql:\"isGroup\""
+	Name        string  "json:\"name\" graphql:\"name\""
+}
+
+func (t *ProjectLabelCreate_ProjectLabelCreate_ProjectLabel) GetColor() string {
+	if t == nil {
+		t = &ProjectLabelCreate_ProjectLabelCreate_ProjectLabel{}
+	}
+	return t.Color
+}
+func (t *ProjectLabelCreate_ProjectLabelCreate_ProjectLabel) GetDescription() *string {
+	if t == nil {
+		t = &ProjectLabelCreate_ProjectLabelCreate_ProjectLabel{}
+	}
+	return t.Description
+}
+func (t *ProjectLabelCreate_ProjectLabelCreate_ProjectLabel) GetID() string {
+	if t == nil {
+		t = &ProjectLabelCreate_ProjectLabelCreate_ProjectLabel{}
+	}
+	return t.ID
+}
+func (t *ProjectLabelCreate_ProjectLabelCreate_ProjectLabel) GetIsGroup() bool {
+	if t == nil {
+		t = &ProjectLabelCreate_ProjectLabelCreate_ProjectLabel{}
+	}
+	return t.IsGroup
+}
+func (t *ProjectLabelCreate_ProjectLabelCreate_ProjectLabel) GetName() string {
+	if t == nil {
+		t = &ProjectLabelCreate_ProjectLabelCreate_ProjectLabel{}
+	}
+	return t.Name
+}
+
+type ProjectLabelCreate_ProjectLabelCreate struct {
+	ProjectLabel ProjectLabelCreate_ProjectLabelCreate_ProjectLabel "json:\"projectLabel\" graphql:\"projectLabel\""
+	Success      bool                                               "json:\"success\" graphql:\"success\""
+}
+
+func (t *ProjectLabelCreate_ProjectLabelCreate) GetProjectLabel() *ProjectLabelCreate_ProjectLabelCreate_ProjectLabel {
+	if t == nil {
+		t = &ProjectLabelCreate_ProjectLabelCreate{}
+	}
+	return &t.ProjectLabel
+}
+func (t *ProjectLabelCreate_ProjectLabelCreate) GetSuccess() bool {
+	if t == nil {
+		t = &ProjectLabelCreate_ProjectLabelCreate{}
+	}
+	return t.Success
+}
+
+type ProjectLabelUpdate_ProjectLabelUpdate_ProjectLabel struct {
+	Color       string  "json:\"color\" graphql:\"color\""
+	Description *string "json:\"description,omitempty\" graphql:\"description\""
+	ID          string  "json:\"id\" graphql:\"id\""
+	IsGroup     bool    "json:\"isGroup\" graphql:\"isGroup\""
+	Name        string  "json:\"name\" graphql:\"name\""
+}
+
+func (t *ProjectLabelUpdate_ProjectLabelUpdate_ProjectLabel) GetColor() string {
+	if t == nil {
+		t = &ProjectLabelUpdate_ProjectLabelUpdate_ProjectLabel{}
+	}
+	return t.Color
+}
+func (t *ProjectLabelUpdate_ProjectLabelUpdate_ProjectLabel) GetDescription() *string {
+	if t == nil {
+		t = &ProjectLabelUpdate_ProjectLabelUpdate_ProjectLabel{}
+	}
+	return t.Description
+}
+func (t *ProjectLabelUpdate_ProjectLabelUpdate_ProjectLabel) GetID() string {
+	if t == nil {
+		t = &ProjectLabelUpdate_ProjectLabelUpdate_ProjectLabel{}
+	}
+	return t.ID
+}
+func (t *ProjectLabelUpdate_ProjectLabelUpdate_ProjectLabel) GetIsGroup() bool {
+	if t == nil {
+		t = &ProjectLabelUpdate_ProjectLabelUpdate_ProjectLabel{}
+	}
+	return t.IsGroup
+}
+func (t *ProjectLabelUpdate_ProjectLabelUpdate_ProjectLabel) GetName() string {
+	if t == nil {
+		t = &ProjectLabelUpdate_ProjectLabelUpdate_ProjectLabel{}
+	}
+	return t.Name
+}
+
+type ProjectLabelUpdate_ProjectLabelUpdate struct {
+	ProjectLabel ProjectLabelUpdate_ProjectLabelUpdate_ProjectLabel "json:\"projectLabel\" graphql:\"projectLabel\""
+	Success      bool                                               "json:\"success\" graphql:\"success\""
+}
+
+func (t *ProjectLabelUpdate_ProjectLabelUpdate) GetProjectLabel() *ProjectLabelUpdate_ProjectLabelUpdate_ProjectLabel {
+	if t == nil {
+		t = &ProjectLabelUpdate_ProjectLabelUpdate{}
+	}
+	return &t.ProjectLabel
+}
+func (t *ProjectLabelUpdate_ProjectLabelUpdate) GetSuccess() bool {
+	if t == nil {
+		t = &ProjectLabelUpdate_ProjectLabelUpdate{}
+	}
+	return t.Success
+}
+
+type ProjectLabelDelete_ProjectLabelDelete struct {
+	Success bool "json:\"success\" graphql:\"success\""
+}
+
+func (t *ProjectLabelDelete_ProjectLabelDelete) GetSuccess() bool {
+	if t == nil {
+		t = &ProjectLabelDelete_ProjectLabelDelete{}
+	}
+	return t.Success
+}
+
+type ProjectRelationCreate_ProjectRelationCreate_ProjectRelation_Project struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *ProjectRelationCreate_ProjectRelationCreate_ProjectRelation_Project) GetID() string {
+	if t == nil {
+		t = &ProjectRelationCreate_ProjectRelationCreate_ProjectRelation_Project{}
+	}
+	return t.ID
+}
+func (t *ProjectRelationCreate_ProjectRelationCreate_ProjectRelation_Project) GetName() string {
+	if t == nil {
+		t = &ProjectRelationCreate_ProjectRelationCreate_ProjectRelation_Project{}
+	}
+	return t.Name
+}
+
+type ProjectRelationCreate_ProjectRelationCreate_ProjectRelation_RelatedProject struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *ProjectRelationCreate_ProjectRelationCreate_ProjectRelation_RelatedProject) GetID() string {
+	if t == nil {
+		t = &ProjectRelationCreate_ProjectRelationCreate_ProjectRelation_RelatedProject{}
+	}
+	return t.ID
+}
+func (t *ProjectRelationCreate_ProjectRelationCreate_ProjectRelation_RelatedProject) GetName() string {
+	if t == nil {
+		t = &ProjectRelationCreate_ProjectRelationCreate_ProjectRelation_RelatedProject{}
+	}
+	return t.Name
+}
+
+type ProjectRelationCreate_ProjectRelationCreate_ProjectRelation struct {
+	AnchorType        string                                                                     "json:\"anchorType\" graphql:\"anchorType\""
+	ID                string                                                                     "json:\"id\" graphql:\"id\""
+	Project           ProjectRelationCreate_ProjectRelationCreate_ProjectRelation_Project        "json:\"project\" graphql:\"project\""
+	RelatedAnchorType string                                                                     "json:\"relatedAnchorType\" graphql:\"relatedAnchorType\""
+	RelatedProject    ProjectRelationCreate_ProjectRelationCreate_ProjectRelation_RelatedProject "json:\"relatedProject\" graphql:\"relatedProject\""
+	Type              string                                                                     "json:\"type\" graphql:\"type\""
+}
+
+func (t *ProjectRelationCreate_ProjectRelationCreate_ProjectRelation) GetAnchorType() string {
+	if t == nil {
+		t = &ProjectRelationCreate_ProjectRelationCreate_ProjectRelation{}
+	}
+	return t.AnchorType
+}
+func (t *ProjectRelationCreate_ProjectRelationCreate_ProjectRelation) GetID() string {
+	if t == nil {
+		t = &ProjectRelationCreate_ProjectRelationCreate_ProjectRelation{}
+	}
+	return t.ID
+}
+func (t *ProjectRelationCreate_ProjectRelationCreate_ProjectRelation) GetProject() *ProjectRelationCreate_ProjectRelationCreate_ProjectRelation_Project {
+	if t == nil {
+		t = &ProjectRelationCreate_ProjectRelationCreate_ProjectRelation{}
+	}
+	return &t.Project
+}
+func (t *ProjectRelationCreate_ProjectRelationCreate_ProjectRelation) GetRelatedAnchorType() string {
+	if t == nil {
+		t = &ProjectRelationCreate_ProjectRelationCreate_ProjectRelation{}
+	}
+	return t.RelatedAnchorType
+}
+func (t *ProjectRelationCreate_ProjectRelationCreate_ProjectRelation) GetRelatedProject() *ProjectRelationCreate_ProjectRelationCreate_ProjectRelation_RelatedProject {
+	if t == nil {
+		t = &ProjectRelationCreate_ProjectRelationCreate_ProjectRelation{}
+	}
+	return &t.RelatedProject
+}
+func (t *ProjectRelationCreate_ProjectRelationCreate_ProjectRelation) GetType() string {
+	if t == nil {
+		t = &ProjectRelationCreate_ProjectRelationCreate_ProjectRelation{}
+	}
+	return t.Type
+}
+
+type ProjectRelationCreate_ProjectRelationCreate struct {
+	ProjectRelation ProjectRelationCreate_ProjectRelationCreate_ProjectRelation "json:\"projectRelation\" graphql:\"projectRelation\""
+	Success         bool                                                        "json:\"success\" graphql:\"success\""
+}
+
+func (t *ProjectRelationCreate_ProjectRelationCreate) GetProjectRelation() *ProjectRelationCreate_ProjectRelationCreate_ProjectRelation {
+	if t == nil {
+		t = &ProjectRelationCreate_ProjectRelationCreate{}
+	}
+	return &t.ProjectRelation
+}
+func (t *ProjectRelationCreate_ProjectRelationCreate) GetSuccess() bool {
+	if t == nil {
+		t = &ProjectRelationCreate_ProjectRelationCreate{}
+	}
+	return t.Success
+}
+
+type ProjectRelationUpdate_ProjectRelationUpdate_ProjectRelation struct {
+	AnchorType        string "json:\"anchorType\" graphql:\"anchorType\""
+	ID                string "json:\"id\" graphql:\"id\""
+	RelatedAnchorType string "json:\"relatedAnchorType\" graphql:\"relatedAnchorType\""
+	Type              string "json:\"type\" graphql:\"type\""
+}
+
+func (t *ProjectRelationUpdate_ProjectRelationUpdate_ProjectRelation) GetAnchorType() string {
+	if t == nil {
+		t = &ProjectRelationUpdate_ProjectRelationUpdate_ProjectRelation{}
+	}
+	return t.AnchorType
+}
+func (t *ProjectRelationUpdate_ProjectRelationUpdate_ProjectRelation) GetID() string {
+	if t == nil {
+		t = &ProjectRelationUpdate_ProjectRelationUpdate_ProjectRelation{}
+	}
+	return t.ID
+}
+func (t *ProjectRelationUpdate_ProjectRelationUpdate_ProjectRelation) GetRelatedAnchorType() string {
+	if t == nil {
+		t = &ProjectRelationUpdate_ProjectRelationUpdate_ProjectRelation{}
+	}
+	return t.RelatedAnchorType
+}
+func (t *ProjectRelationUpdate_ProjectRelationUpdate_ProjectRelation) GetType() string {
+	if t == nil {
+		t = &ProjectRelationUpdate_ProjectRelationUpdate_ProjectRelation{}
+	}
+	return t.Type
+}
+
+type ProjectRelationUpdate_ProjectRelationUpdate struct {
+	ProjectRelation ProjectRelationUpdate_ProjectRelationUpdate_ProjectRelation "json:\"projectRelation\" graphql:\"projectRelation\""
+	Success         bool                                                        "json:\"success\" graphql:\"success\""
+}
+
+func (t *ProjectRelationUpdate_ProjectRelationUpdate) GetProjectRelation() *ProjectRelationUpdate_ProjectRelationUpdate_ProjectRelation {
+	if t == nil {
+		t = &ProjectRelationUpdate_ProjectRelationUpdate{}
+	}
+	return &t.ProjectRelation
+}
+func (t *ProjectRelationUpdate_ProjectRelationUpdate) GetSuccess() bool {
+	if t == nil {
+		t = &ProjectRelationUpdate_ProjectRelationUpdate{}
+	}
+	return t.Success
+}
+
+type ProjectRelationDelete_ProjectRelationDelete struct {
+	Success bool "json:\"success\" graphql:\"success\""
+}
+
+func (t *ProjectRelationDelete_ProjectRelationDelete) GetSuccess() bool {
+	if t == nil {
+		t = &ProjectRelationDelete_ProjectRelationDelete{}
+	}
+	return t.Success
+}
+
 type ReactionCreate_ReactionCreate_Reaction_User struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
@@ -7661,6 +7956,238 @@ func (t *ListProjectsFiltered_Projects) GetNodes() []*ListProjectsFiltered_Proje
 func (t *ListProjectsFiltered_Projects) GetPageInfo() *ListProjectsFiltered_Projects_PageInfo {
 	if t == nil {
 		t = &ListProjectsFiltered_Projects{}
+	}
+	return &t.PageInfo
+}
+
+type ListProjectLabels_ProjectLabels_Nodes struct {
+	Color       string  "json:\"color\" graphql:\"color\""
+	Description *string "json:\"description,omitempty\" graphql:\"description\""
+	ID          string  "json:\"id\" graphql:\"id\""
+	IsGroup     bool    "json:\"isGroup\" graphql:\"isGroup\""
+	Name        string  "json:\"name\" graphql:\"name\""
+}
+
+func (t *ListProjectLabels_ProjectLabels_Nodes) GetColor() string {
+	if t == nil {
+		t = &ListProjectLabels_ProjectLabels_Nodes{}
+	}
+	return t.Color
+}
+func (t *ListProjectLabels_ProjectLabels_Nodes) GetDescription() *string {
+	if t == nil {
+		t = &ListProjectLabels_ProjectLabels_Nodes{}
+	}
+	return t.Description
+}
+func (t *ListProjectLabels_ProjectLabels_Nodes) GetID() string {
+	if t == nil {
+		t = &ListProjectLabels_ProjectLabels_Nodes{}
+	}
+	return t.ID
+}
+func (t *ListProjectLabels_ProjectLabels_Nodes) GetIsGroup() bool {
+	if t == nil {
+		t = &ListProjectLabels_ProjectLabels_Nodes{}
+	}
+	return t.IsGroup
+}
+func (t *ListProjectLabels_ProjectLabels_Nodes) GetName() string {
+	if t == nil {
+		t = &ListProjectLabels_ProjectLabels_Nodes{}
+	}
+	return t.Name
+}
+
+type ListProjectLabels_ProjectLabels_PageInfo struct {
+	EndCursor   *string "json:\"endCursor,omitempty\" graphql:\"endCursor\""
+	HasNextPage bool    "json:\"hasNextPage\" graphql:\"hasNextPage\""
+}
+
+func (t *ListProjectLabels_ProjectLabels_PageInfo) GetEndCursor() *string {
+	if t == nil {
+		t = &ListProjectLabels_ProjectLabels_PageInfo{}
+	}
+	return t.EndCursor
+}
+func (t *ListProjectLabels_ProjectLabels_PageInfo) GetHasNextPage() bool {
+	if t == nil {
+		t = &ListProjectLabels_ProjectLabels_PageInfo{}
+	}
+	return t.HasNextPage
+}
+
+type ListProjectLabels_ProjectLabels struct {
+	Nodes    []*ListProjectLabels_ProjectLabels_Nodes "json:\"nodes\" graphql:\"nodes\""
+	PageInfo ListProjectLabels_ProjectLabels_PageInfo "json:\"pageInfo\" graphql:\"pageInfo\""
+}
+
+func (t *ListProjectLabels_ProjectLabels) GetNodes() []*ListProjectLabels_ProjectLabels_Nodes {
+	if t == nil {
+		t = &ListProjectLabels_ProjectLabels{}
+	}
+	return t.Nodes
+}
+func (t *ListProjectLabels_ProjectLabels) GetPageInfo() *ListProjectLabels_ProjectLabels_PageInfo {
+	if t == nil {
+		t = &ListProjectLabels_ProjectLabels{}
+	}
+	return &t.PageInfo
+}
+
+type GetProjectLabel_ProjectLabel struct {
+	Color       string  "json:\"color\" graphql:\"color\""
+	Description *string "json:\"description,omitempty\" graphql:\"description\""
+	ID          string  "json:\"id\" graphql:\"id\""
+	IsGroup     bool    "json:\"isGroup\" graphql:\"isGroup\""
+	Name        string  "json:\"name\" graphql:\"name\""
+}
+
+func (t *GetProjectLabel_ProjectLabel) GetColor() string {
+	if t == nil {
+		t = &GetProjectLabel_ProjectLabel{}
+	}
+	return t.Color
+}
+func (t *GetProjectLabel_ProjectLabel) GetDescription() *string {
+	if t == nil {
+		t = &GetProjectLabel_ProjectLabel{}
+	}
+	return t.Description
+}
+func (t *GetProjectLabel_ProjectLabel) GetID() string {
+	if t == nil {
+		t = &GetProjectLabel_ProjectLabel{}
+	}
+	return t.ID
+}
+func (t *GetProjectLabel_ProjectLabel) GetIsGroup() bool {
+	if t == nil {
+		t = &GetProjectLabel_ProjectLabel{}
+	}
+	return t.IsGroup
+}
+func (t *GetProjectLabel_ProjectLabel) GetName() string {
+	if t == nil {
+		t = &GetProjectLabel_ProjectLabel{}
+	}
+	return t.Name
+}
+
+type ListProjectRelations_ProjectRelations_Nodes_Project struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *ListProjectRelations_ProjectRelations_Nodes_Project) GetID() string {
+	if t == nil {
+		t = &ListProjectRelations_ProjectRelations_Nodes_Project{}
+	}
+	return t.ID
+}
+func (t *ListProjectRelations_ProjectRelations_Nodes_Project) GetName() string {
+	if t == nil {
+		t = &ListProjectRelations_ProjectRelations_Nodes_Project{}
+	}
+	return t.Name
+}
+
+type ListProjectRelations_ProjectRelations_Nodes_RelatedProject struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *ListProjectRelations_ProjectRelations_Nodes_RelatedProject) GetID() string {
+	if t == nil {
+		t = &ListProjectRelations_ProjectRelations_Nodes_RelatedProject{}
+	}
+	return t.ID
+}
+func (t *ListProjectRelations_ProjectRelations_Nodes_RelatedProject) GetName() string {
+	if t == nil {
+		t = &ListProjectRelations_ProjectRelations_Nodes_RelatedProject{}
+	}
+	return t.Name
+}
+
+type ListProjectRelations_ProjectRelations_Nodes struct {
+	AnchorType        string                                                     "json:\"anchorType\" graphql:\"anchorType\""
+	ID                string                                                     "json:\"id\" graphql:\"id\""
+	Project           ListProjectRelations_ProjectRelations_Nodes_Project        "json:\"project\" graphql:\"project\""
+	RelatedAnchorType string                                                     "json:\"relatedAnchorType\" graphql:\"relatedAnchorType\""
+	RelatedProject    ListProjectRelations_ProjectRelations_Nodes_RelatedProject "json:\"relatedProject\" graphql:\"relatedProject\""
+	Type              string                                                     "json:\"type\" graphql:\"type\""
+}
+
+func (t *ListProjectRelations_ProjectRelations_Nodes) GetAnchorType() string {
+	if t == nil {
+		t = &ListProjectRelations_ProjectRelations_Nodes{}
+	}
+	return t.AnchorType
+}
+func (t *ListProjectRelations_ProjectRelations_Nodes) GetID() string {
+	if t == nil {
+		t = &ListProjectRelations_ProjectRelations_Nodes{}
+	}
+	return t.ID
+}
+func (t *ListProjectRelations_ProjectRelations_Nodes) GetProject() *ListProjectRelations_ProjectRelations_Nodes_Project {
+	if t == nil {
+		t = &ListProjectRelations_ProjectRelations_Nodes{}
+	}
+	return &t.Project
+}
+func (t *ListProjectRelations_ProjectRelations_Nodes) GetRelatedAnchorType() string {
+	if t == nil {
+		t = &ListProjectRelations_ProjectRelations_Nodes{}
+	}
+	return t.RelatedAnchorType
+}
+func (t *ListProjectRelations_ProjectRelations_Nodes) GetRelatedProject() *ListProjectRelations_ProjectRelations_Nodes_RelatedProject {
+	if t == nil {
+		t = &ListProjectRelations_ProjectRelations_Nodes{}
+	}
+	return &t.RelatedProject
+}
+func (t *ListProjectRelations_ProjectRelations_Nodes) GetType() string {
+	if t == nil {
+		t = &ListProjectRelations_ProjectRelations_Nodes{}
+	}
+	return t.Type
+}
+
+type ListProjectRelations_ProjectRelations_PageInfo struct {
+	EndCursor   *string "json:\"endCursor,omitempty\" graphql:\"endCursor\""
+	HasNextPage bool    "json:\"hasNextPage\" graphql:\"hasNextPage\""
+}
+
+func (t *ListProjectRelations_ProjectRelations_PageInfo) GetEndCursor() *string {
+	if t == nil {
+		t = &ListProjectRelations_ProjectRelations_PageInfo{}
+	}
+	return t.EndCursor
+}
+func (t *ListProjectRelations_ProjectRelations_PageInfo) GetHasNextPage() bool {
+	if t == nil {
+		t = &ListProjectRelations_ProjectRelations_PageInfo{}
+	}
+	return t.HasNextPage
+}
+
+type ListProjectRelations_ProjectRelations struct {
+	Nodes    []*ListProjectRelations_ProjectRelations_Nodes "json:\"nodes\" graphql:\"nodes\""
+	PageInfo ListProjectRelations_ProjectRelations_PageInfo "json:\"pageInfo\" graphql:\"pageInfo\""
+}
+
+func (t *ListProjectRelations_ProjectRelations) GetNodes() []*ListProjectRelations_ProjectRelations_Nodes {
+	if t == nil {
+		t = &ListProjectRelations_ProjectRelations{}
+	}
+	return t.Nodes
+}
+func (t *ListProjectRelations_ProjectRelations) GetPageInfo() *ListProjectRelations_ProjectRelations_PageInfo {
+	if t == nil {
+		t = &ListProjectRelations_ProjectRelations{}
 	}
 	return &t.PageInfo
 }
@@ -9969,6 +10496,72 @@ func (t *UnarchiveProject) GetProjectUnarchive() *UnarchiveProject_ProjectUnarch
 	return &t.ProjectUnarchive
 }
 
+type ProjectLabelCreate struct {
+	ProjectLabelCreate ProjectLabelCreate_ProjectLabelCreate "json:\"projectLabelCreate\" graphql:\"projectLabelCreate\""
+}
+
+func (t *ProjectLabelCreate) GetProjectLabelCreate() *ProjectLabelCreate_ProjectLabelCreate {
+	if t == nil {
+		t = &ProjectLabelCreate{}
+	}
+	return &t.ProjectLabelCreate
+}
+
+type ProjectLabelUpdate struct {
+	ProjectLabelUpdate ProjectLabelUpdate_ProjectLabelUpdate "json:\"projectLabelUpdate\" graphql:\"projectLabelUpdate\""
+}
+
+func (t *ProjectLabelUpdate) GetProjectLabelUpdate() *ProjectLabelUpdate_ProjectLabelUpdate {
+	if t == nil {
+		t = &ProjectLabelUpdate{}
+	}
+	return &t.ProjectLabelUpdate
+}
+
+type ProjectLabelDelete struct {
+	ProjectLabelDelete ProjectLabelDelete_ProjectLabelDelete "json:\"projectLabelDelete\" graphql:\"projectLabelDelete\""
+}
+
+func (t *ProjectLabelDelete) GetProjectLabelDelete() *ProjectLabelDelete_ProjectLabelDelete {
+	if t == nil {
+		t = &ProjectLabelDelete{}
+	}
+	return &t.ProjectLabelDelete
+}
+
+type ProjectRelationCreate struct {
+	ProjectRelationCreate ProjectRelationCreate_ProjectRelationCreate "json:\"projectRelationCreate\" graphql:\"projectRelationCreate\""
+}
+
+func (t *ProjectRelationCreate) GetProjectRelationCreate() *ProjectRelationCreate_ProjectRelationCreate {
+	if t == nil {
+		t = &ProjectRelationCreate{}
+	}
+	return &t.ProjectRelationCreate
+}
+
+type ProjectRelationUpdate struct {
+	ProjectRelationUpdate ProjectRelationUpdate_ProjectRelationUpdate "json:\"projectRelationUpdate\" graphql:\"projectRelationUpdate\""
+}
+
+func (t *ProjectRelationUpdate) GetProjectRelationUpdate() *ProjectRelationUpdate_ProjectRelationUpdate {
+	if t == nil {
+		t = &ProjectRelationUpdate{}
+	}
+	return &t.ProjectRelationUpdate
+}
+
+type ProjectRelationDelete struct {
+	ProjectRelationDelete ProjectRelationDelete_ProjectRelationDelete "json:\"projectRelationDelete\" graphql:\"projectRelationDelete\""
+}
+
+func (t *ProjectRelationDelete) GetProjectRelationDelete() *ProjectRelationDelete_ProjectRelationDelete {
+	if t == nil {
+		t = &ProjectRelationDelete{}
+	}
+	return &t.ProjectRelationDelete
+}
+
 type ReactionCreate struct {
 	ReactionCreate ReactionCreate_ReactionCreate "json:\"reactionCreate\" graphql:\"reactionCreate\""
 }
@@ -10154,6 +10747,39 @@ func (t *ListProjectsFiltered) GetProjects() *ListProjectsFiltered_Projects {
 		t = &ListProjectsFiltered{}
 	}
 	return &t.Projects
+}
+
+type ListProjectLabels struct {
+	ProjectLabels ListProjectLabels_ProjectLabels "json:\"projectLabels\" graphql:\"projectLabels\""
+}
+
+func (t *ListProjectLabels) GetProjectLabels() *ListProjectLabels_ProjectLabels {
+	if t == nil {
+		t = &ListProjectLabels{}
+	}
+	return &t.ProjectLabels
+}
+
+type GetProjectLabel struct {
+	ProjectLabel GetProjectLabel_ProjectLabel "json:\"projectLabel\" graphql:\"projectLabel\""
+}
+
+func (t *GetProjectLabel) GetProjectLabel() *GetProjectLabel_ProjectLabel {
+	if t == nil {
+		t = &GetProjectLabel{}
+	}
+	return &t.ProjectLabel
+}
+
+type ListProjectRelations struct {
+	ProjectRelations ListProjectRelations_ProjectRelations "json:\"projectRelations\" graphql:\"projectRelations\""
+}
+
+func (t *ListProjectRelations) GetProjectRelations() *ListProjectRelations_ProjectRelations {
+	if t == nil {
+		t = &ListProjectRelations{}
+	}
+	return &t.ProjectRelations
 }
 
 type GetRoadmap struct {
@@ -13112,6 +13738,186 @@ func (c *Client) UnarchiveProject(ctx context.Context, id string, interceptors .
 	return &res, nil
 }
 
+const ProjectLabelCreateDocument = `mutation ProjectLabelCreate ($input: ProjectLabelCreateInput!) {
+	projectLabelCreate(input: $input) {
+		success
+		projectLabel {
+			id
+			name
+			color
+			description
+			isGroup
+		}
+	}
+}
+`
+
+func (c *Client) ProjectLabelCreate(ctx context.Context, input ProjectLabelCreateInput, interceptors ...clientv2.RequestInterceptor) (*ProjectLabelCreate, error) {
+	vars := map[string]any{
+		"input": input,
+	}
+
+	var res ProjectLabelCreate
+	if err := c.Client.Post(ctx, "ProjectLabelCreate", ProjectLabelCreateDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const ProjectLabelUpdateDocument = `mutation ProjectLabelUpdate ($id: String!, $input: ProjectLabelUpdateInput!) {
+	projectLabelUpdate(id: $id, input: $input) {
+		success
+		projectLabel {
+			id
+			name
+			color
+			description
+			isGroup
+		}
+	}
+}
+`
+
+func (c *Client) ProjectLabelUpdate(ctx context.Context, id string, input ProjectLabelUpdateInput, interceptors ...clientv2.RequestInterceptor) (*ProjectLabelUpdate, error) {
+	vars := map[string]any{
+		"id":    id,
+		"input": input,
+	}
+
+	var res ProjectLabelUpdate
+	if err := c.Client.Post(ctx, "ProjectLabelUpdate", ProjectLabelUpdateDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const ProjectLabelDeleteDocument = `mutation ProjectLabelDelete ($id: String!) {
+	projectLabelDelete(id: $id) {
+		success
+	}
+}
+`
+
+func (c *Client) ProjectLabelDelete(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*ProjectLabelDelete, error) {
+	vars := map[string]any{
+		"id": id,
+	}
+
+	var res ProjectLabelDelete
+	if err := c.Client.Post(ctx, "ProjectLabelDelete", ProjectLabelDeleteDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const ProjectRelationCreateDocument = `mutation ProjectRelationCreate ($input: ProjectRelationCreateInput!) {
+	projectRelationCreate(input: $input) {
+		success
+		projectRelation {
+			id
+			type
+			anchorType
+			relatedAnchorType
+			project {
+				id
+				name
+			}
+			relatedProject {
+				id
+				name
+			}
+		}
+	}
+}
+`
+
+func (c *Client) ProjectRelationCreate(ctx context.Context, input ProjectRelationCreateInput, interceptors ...clientv2.RequestInterceptor) (*ProjectRelationCreate, error) {
+	vars := map[string]any{
+		"input": input,
+	}
+
+	var res ProjectRelationCreate
+	if err := c.Client.Post(ctx, "ProjectRelationCreate", ProjectRelationCreateDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const ProjectRelationUpdateDocument = `mutation ProjectRelationUpdate ($id: String!, $input: ProjectRelationUpdateInput!) {
+	projectRelationUpdate(id: $id, input: $input) {
+		success
+		projectRelation {
+			id
+			type
+			anchorType
+			relatedAnchorType
+		}
+	}
+}
+`
+
+func (c *Client) ProjectRelationUpdate(ctx context.Context, id string, input ProjectRelationUpdateInput, interceptors ...clientv2.RequestInterceptor) (*ProjectRelationUpdate, error) {
+	vars := map[string]any{
+		"id":    id,
+		"input": input,
+	}
+
+	var res ProjectRelationUpdate
+	if err := c.Client.Post(ctx, "ProjectRelationUpdate", ProjectRelationUpdateDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const ProjectRelationDeleteDocument = `mutation ProjectRelationDelete ($id: String!) {
+	projectRelationDelete(id: $id) {
+		success
+	}
+}
+`
+
+func (c *Client) ProjectRelationDelete(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*ProjectRelationDelete, error) {
+	vars := map[string]any{
+		"id": id,
+	}
+
+	var res ProjectRelationDelete
+	if err := c.Client.Post(ctx, "ProjectRelationDelete", ProjectRelationDeleteDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
 const ReactionCreateDocument = `mutation ReactionCreate ($input: ReactionCreateInput!) {
 	reactionCreate(input: $input) {
 		success
@@ -13747,6 +14553,111 @@ func (c *Client) ListProjectsFiltered(ctx context.Context, first *int64, after *
 
 	var res ListProjectsFiltered
 	if err := c.Client.Post(ctx, "ListProjectsFiltered", ListProjectsFilteredDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const ListProjectLabelsDocument = `query ListProjectLabels ($first: Int, $after: String) {
+	projectLabels(first: $first, after: $after) {
+		nodes {
+			id
+			name
+			color
+			description
+			isGroup
+		}
+		pageInfo {
+			hasNextPage
+			endCursor
+		}
+	}
+}
+`
+
+func (c *Client) ListProjectLabels(ctx context.Context, first *int64, after *string, interceptors ...clientv2.RequestInterceptor) (*ListProjectLabels, error) {
+	vars := map[string]any{
+		"first": first,
+		"after": after,
+	}
+
+	var res ListProjectLabels
+	if err := c.Client.Post(ctx, "ListProjectLabels", ListProjectLabelsDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const GetProjectLabelDocument = `query GetProjectLabel ($id: String!) {
+	projectLabel(id: $id) {
+		id
+		name
+		color
+		description
+		isGroup
+	}
+}
+`
+
+func (c *Client) GetProjectLabel(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*GetProjectLabel, error) {
+	vars := map[string]any{
+		"id": id,
+	}
+
+	var res GetProjectLabel
+	if err := c.Client.Post(ctx, "GetProjectLabel", GetProjectLabelDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const ListProjectRelationsDocument = `query ListProjectRelations ($first: Int, $after: String) {
+	projectRelations(first: $first, after: $after) {
+		nodes {
+			id
+			type
+			anchorType
+			relatedAnchorType
+			project {
+				id
+				name
+			}
+			relatedProject {
+				id
+				name
+			}
+		}
+		pageInfo {
+			hasNextPage
+			endCursor
+		}
+	}
+}
+`
+
+func (c *Client) ListProjectRelations(ctx context.Context, first *int64, after *string, interceptors ...clientv2.RequestInterceptor) (*ListProjectRelations, error) {
+	vars := map[string]any{
+		"first": first,
+		"after": after,
+	}
+
+	var res ListProjectRelations
+	if err := c.Client.Post(ctx, "ListProjectRelations", ListProjectRelationsDocument, &res, vars, interceptors...); err != nil {
 		if c.Client.ParseDataWhenErrors {
 			return &res, err
 		}
@@ -14421,6 +15332,12 @@ var DocumentOperationNames = map[string]string{
 	DeleteProjectDocument:                  "DeleteProject",
 	ArchiveProjectDocument:                 "ArchiveProject",
 	UnarchiveProjectDocument:               "UnarchiveProject",
+	ProjectLabelCreateDocument:             "ProjectLabelCreate",
+	ProjectLabelUpdateDocument:             "ProjectLabelUpdate",
+	ProjectLabelDeleteDocument:             "ProjectLabelDelete",
+	ProjectRelationCreateDocument:          "ProjectRelationCreate",
+	ProjectRelationUpdateDocument:          "ProjectRelationUpdate",
+	ProjectRelationDeleteDocument:          "ProjectRelationDelete",
 	ReactionCreateDocument:                 "ReactionCreate",
 	ReactionDeleteDocument:                 "ReactionDelete",
 	AddTeamMemberDocument:                  "AddTeamMember",
@@ -14438,6 +15355,9 @@ var DocumentOperationNames = map[string]string{
 	GetProjectDocument:                     "GetProject",
 	ListProjectsDocument:                   "ListProjects",
 	ListProjectsFilteredDocument:           "ListProjectsFiltered",
+	ListProjectLabelsDocument:              "ListProjectLabels",
+	GetProjectLabelDocument:                "GetProjectLabel",
+	ListProjectRelationsDocument:           "ListProjectRelations",
 	GetRoadmapDocument:                     "GetRoadmap",
 	ListRoadmapsDocument:                   "ListRoadmaps",
 	SearchIssuesDocument:                   "SearchIssues",

--- a/pkg/linear/client_project_labels.go
+++ b/pkg/linear/client_project_labels.go
@@ -1,0 +1,61 @@
+package linear
+
+import (
+	"context"
+
+	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
+)
+
+// ProjectLabels retrieves a paginated list of project labels.
+func (c *Client) ProjectLabels(ctx context.Context, first *int64, after *string) (*intgraphql.ListProjectLabels_ProjectLabels, error) {
+	resp, err := c.gqlClient.ListProjectLabels(ctx, first, after)
+	if err != nil {
+		return nil, wrapGraphQLError("project labels query", err)
+	}
+	return &resp.ProjectLabels, nil
+}
+
+// ProjectLabel retrieves a single project label by ID.
+func (c *Client) ProjectLabel(ctx context.Context, id string) (*intgraphql.GetProjectLabel_ProjectLabel, error) {
+	resp, err := c.gqlClient.GetProjectLabel(ctx, id)
+	if err != nil {
+		return nil, wrapGraphQLError("project label query", err)
+	}
+	return &resp.ProjectLabel, nil
+}
+
+// ProjectLabelCreate creates a new project label.
+func (c *Client) ProjectLabelCreate(ctx context.Context, input intgraphql.ProjectLabelCreateInput) (*intgraphql.ProjectLabelCreate_ProjectLabelCreate_ProjectLabel, error) {
+	resp, err := c.gqlClient.ProjectLabelCreate(ctx, input)
+	if err != nil {
+		return nil, wrapGraphQLError("ProjectLabelCreate", err)
+	}
+	if !resp.ProjectLabelCreate.Success {
+		return nil, errMutationFailed("ProjectLabelCreate")
+	}
+	return &resp.ProjectLabelCreate.ProjectLabel, nil
+}
+
+// ProjectLabelUpdate updates an existing project label.
+func (c *Client) ProjectLabelUpdate(ctx context.Context, id string, input intgraphql.ProjectLabelUpdateInput) (*intgraphql.ProjectLabelUpdate_ProjectLabelUpdate_ProjectLabel, error) {
+	resp, err := c.gqlClient.ProjectLabelUpdate(ctx, id, input)
+	if err != nil {
+		return nil, wrapGraphQLError("ProjectLabelUpdate", err)
+	}
+	if !resp.ProjectLabelUpdate.Success {
+		return nil, errMutationFailed("ProjectLabelUpdate")
+	}
+	return &resp.ProjectLabelUpdate.ProjectLabel, nil
+}
+
+// ProjectLabelDelete deletes a project label by ID.
+func (c *Client) ProjectLabelDelete(ctx context.Context, id string) error {
+	resp, err := c.gqlClient.ProjectLabelDelete(ctx, id)
+	if err != nil {
+		return wrapGraphQLError("ProjectLabelDelete", err)
+	}
+	if !resp.ProjectLabelDelete.Success {
+		return errMutationFailed("ProjectLabelDelete")
+	}
+	return nil
+}

--- a/pkg/linear/client_project_relations.go
+++ b/pkg/linear/client_project_relations.go
@@ -1,0 +1,52 @@
+package linear
+
+import (
+	"context"
+
+	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
+)
+
+// ProjectRelations retrieves a paginated list of project relations.
+func (c *Client) ProjectRelations(ctx context.Context, first *int64, after *string) (*intgraphql.ListProjectRelations_ProjectRelations, error) {
+	resp, err := c.gqlClient.ListProjectRelations(ctx, first, after)
+	if err != nil {
+		return nil, wrapGraphQLError("project relations query", err)
+	}
+	return &resp.ProjectRelations, nil
+}
+
+// ProjectRelationCreate creates a new project relation.
+func (c *Client) ProjectRelationCreate(ctx context.Context, input intgraphql.ProjectRelationCreateInput) (*intgraphql.ProjectRelationCreate_ProjectRelationCreate_ProjectRelation, error) {
+	resp, err := c.gqlClient.ProjectRelationCreate(ctx, input)
+	if err != nil {
+		return nil, wrapGraphQLError("ProjectRelationCreate", err)
+	}
+	if !resp.ProjectRelationCreate.Success {
+		return nil, errMutationFailed("ProjectRelationCreate")
+	}
+	return &resp.ProjectRelationCreate.ProjectRelation, nil
+}
+
+// ProjectRelationUpdate updates an existing project relation.
+func (c *Client) ProjectRelationUpdate(ctx context.Context, id string, input intgraphql.ProjectRelationUpdateInput) (*intgraphql.ProjectRelationUpdate_ProjectRelationUpdate_ProjectRelation, error) {
+	resp, err := c.gqlClient.ProjectRelationUpdate(ctx, id, input)
+	if err != nil {
+		return nil, wrapGraphQLError("ProjectRelationUpdate", err)
+	}
+	if !resp.ProjectRelationUpdate.Success {
+		return nil, errMutationFailed("ProjectRelationUpdate")
+	}
+	return &resp.ProjectRelationUpdate.ProjectRelation, nil
+}
+
+// ProjectRelationDelete deletes a project relation by ID.
+func (c *Client) ProjectRelationDelete(ctx context.Context, id string) error {
+	resp, err := c.gqlClient.ProjectRelationDelete(ctx, id)
+	if err != nil {
+		return wrapGraphQLError("ProjectRelationDelete", err)
+	}
+	if !resp.ProjectRelationDelete.Success {
+		return errMutationFailed("ProjectRelationDelete")
+	}
+	return nil
+}

--- a/queries/mutations/projects.graphql
+++ b/queries/mutations/projects.graphql
@@ -42,3 +42,73 @@ mutation UnarchiveProject($id: String!) {
     success
   }
 }
+
+mutation ProjectLabelCreate($input: ProjectLabelCreateInput!) {
+  projectLabelCreate(input: $input) {
+    success
+    projectLabel {
+      id
+      name
+      color
+      description
+      isGroup
+    }
+  }
+}
+
+mutation ProjectLabelUpdate($id: String!, $input: ProjectLabelUpdateInput!) {
+  projectLabelUpdate(id: $id, input: $input) {
+    success
+    projectLabel {
+      id
+      name
+      color
+      description
+      isGroup
+    }
+  }
+}
+
+mutation ProjectLabelDelete($id: String!) {
+  projectLabelDelete(id: $id) {
+    success
+  }
+}
+
+mutation ProjectRelationCreate($input: ProjectRelationCreateInput!) {
+  projectRelationCreate(input: $input) {
+    success
+    projectRelation {
+      id
+      type
+      anchorType
+      relatedAnchorType
+      project {
+        id
+        name
+      }
+      relatedProject {
+        id
+        name
+      }
+    }
+  }
+}
+
+mutation ProjectRelationUpdate($id: String!, $input: ProjectRelationUpdateInput!) {
+  projectRelationUpdate(id: $id, input: $input) {
+    success
+    projectRelation {
+      id
+      type
+      anchorType
+      relatedAnchorType
+    }
+  }
+}
+
+mutation ProjectRelationDelete($id: String!) {
+  projectRelationDelete(id: $id) {
+    success
+  }
+}

--- a/queries/projects.graphql
+++ b/queries/projects.graphql
@@ -99,3 +99,52 @@ query ListProjectsFiltered($first: Int, $after: String, $filter: ProjectFilter) 
     }
   }
 }
+
+query ListProjectLabels($first: Int, $after: String) {
+  projectLabels(first: $first, after: $after) {
+    nodes {
+      id
+      name
+      color
+      description
+      isGroup
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+
+query GetProjectLabel($id: String!) {
+  projectLabel(id: $id) {
+    id
+    name
+    color
+    description
+    isGroup
+  }
+}
+
+query ListProjectRelations($first: Int, $after: String) {
+  projectRelations(first: $first, after: $after) {
+    nodes {
+      id
+      type
+      anchorType
+      relatedAnchorType
+      project {
+        id
+        name
+      }
+      relatedProject {
+        id
+        name
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds project label CRUD: `label-list`, `label-create`, `label-update`, `label-delete`
- Adds project relation CRUD: `relation-list`, `relation-create`, `relation-update`, `relation-delete`
- 3 new GraphQL queries, 6 new mutations, 8 CLI commands
- Client-side enum validation for relation `--type` and anchor types
- Pagination (`--limit`/`--after`) on list commands

Closes #52
