### PR TITLE
feat(audit): add audit log commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+**Audit Log** (2 commands, requires Admin or Owner role):
+- `audit list` — paginated listing with filters: `--type`, `--actor` (name/email/ID), `--ip`, `--country-code`, `--created-after`, `--created-before`
+- `audit types` — list all valid `--type` values with descriptions
+
 **Lifecycle Management** (12 commands):
 - `issue archive` / `issue unarchive` / `issue delete --permanent`
 - `initiative archive` / `initiative unarchive` / `initiative list-sub`

--- a/cmd/linear/commands/audit/audit.go
+++ b/cmd/linear/commands/audit/audit.go
@@ -1,0 +1,22 @@
+// Package audit provides audit log commands for the Linear CLI.
+package audit
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+)
+
+// NewAuditCommand creates the audit command group.
+func NewAuditCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "audit",
+		Short: "View audit logs",
+		Long:  "Commands for viewing audit log entries and available audit entry types.",
+	}
+
+	cmd.AddCommand(NewListCommand(clientFactory))
+	cmd.AddCommand(NewTypesCommand(clientFactory))
+
+	return cmd
+}

--- a/cmd/linear/commands/audit/audit_test.go
+++ b/cmd/linear/commands/audit/audit_test.go
@@ -92,7 +92,7 @@ func TestRunList(t *testing.T) {
 		cmd := NewListCommand(factory)
 		var buf bytes.Buffer
 		cmd.SetOut(&buf)
-		cmd.SetArgs([]string{"--created-before=2025-12-31"})
+		cmd.SetArgs([]string{"--created-before=7d"})
 
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
@@ -300,7 +300,7 @@ func TestRunListCreatedBeforeVariables(t *testing.T) {
 	cmd := NewListCommand(factory)
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--created-before=2025-12-31"})
+	cmd.SetArgs([]string{"--created-before=7d"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -338,7 +338,7 @@ func TestRunListCreatedDateRange(t *testing.T) {
 	cmd := NewListCommand(factory)
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--created-after=7d", "--created-before=2025-12-31"})
+	cmd.SetArgs([]string{"--created-after=30d", "--created-before=7d"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -361,6 +361,26 @@ func TestRunListCreatedDateRange(t *testing.T) {
 	}
 	if _, ok := createdAt["lte"].(string); !ok {
 		t.Errorf("createdAt.lte missing or not string, got %T", createdAt["lte"])
+	}
+}
+
+func TestRunListInvertedDateRange(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewListCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	// after=7d is ~April 2026, before=30d is ~April 2026 but earlier — inverted
+	cmd.SetArgs([]string{"--created-after=7d", "--created-before=30d"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() expected error for inverted date range, got nil")
+	}
+	if !strings.Contains(err.Error(), "created-after") || !strings.Contains(err.Error(), "created-before") {
+		t.Errorf("error %q should mention both flags", err.Error())
 	}
 }
 

--- a/cmd/linear/commands/audit/audit_test.go
+++ b/cmd/linear/commands/audit/audit_test.go
@@ -34,7 +34,7 @@ func TestNewListCommand(t *testing.T) {
 		t.Errorf("Use = %q, want %q", cmd.Use, "list")
 	}
 
-	expectedFlags := []string{"type", "actor", "ip", "country-code", "created-after", "created-before", "limit"}
+	expectedFlags := []string{"type", "actor", "ip", "country-code", "created-after", "created-before", "limit", "after"}
 	for _, flag := range expectedFlags {
 		if cmd.Flags().Lookup(flag) == nil {
 			t.Errorf("Expected flag %q not found", flag)
@@ -409,6 +409,25 @@ func TestRunListInvertedDateRange(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "created-after") || !strings.Contains(err.Error(), "created-before") {
 		t.Errorf("error %q should mention both flags", err.Error())
+	}
+}
+
+func TestRunListInvalidCreatedBefore(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewListCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--created-before=not-a-date"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() expected error for invalid --created-before, got nil")
+	}
+	if !strings.Contains(err.Error(), "created-before") {
+		t.Errorf("error %q should mention 'created-before'", err.Error())
 	}
 }
 

--- a/cmd/linear/commands/audit/audit_test.go
+++ b/cmd/linear/commands/audit/audit_test.go
@@ -3,7 +3,9 @@ package audit
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/chainguard-sandbox/go-linear/v2/internal/testutil"
 )
@@ -107,6 +109,125 @@ func TestRunList(t *testing.T) {
 			t.Fatalf("Execute() error = %v", err)
 		}
 	})
+}
+
+func TestRunListCreatedAfterVariables(t *testing.T) {
+	server, lastVars := testutil.MockServerCapture(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewListCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--created-after=7d"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	vars := lastVars()
+	if vars == nil {
+		t.Fatal("no variables captured")
+	}
+
+	filter, ok := vars["filter"].(map[string]any)
+	if !ok {
+		t.Fatalf("variables[filter] = %T, want map", vars["filter"])
+	}
+	createdAt, ok := filter["createdAt"].(map[string]any)
+	if !ok {
+		t.Fatalf("filter[createdAt] = %T, want map", filter["createdAt"])
+	}
+	gte, ok := createdAt["gte"].(string)
+	if !ok {
+		t.Fatalf("createdAt[gte] = %T, want string", createdAt["gte"])
+	}
+
+	parsed, err := time.Parse(time.RFC3339, gte)
+	if err != nil {
+		t.Fatalf("createdAt.gte %q is not valid RFC3339: %v", gte, err)
+	}
+
+	// Should be approximately 7 days ago — within a 1-day window either side
+	expected := time.Now().UTC().Add(-7 * 24 * time.Hour)
+	diff := parsed.Sub(expected)
+	if diff < -25*time.Hour || diff > 25*time.Hour {
+		t.Errorf("createdAt.gte = %v, want ~7 days ago (%v)", parsed, expected)
+	}
+}
+
+func TestRunListActorResolvesName(t *testing.T) {
+	handlers := defaultHandlers()
+	handlers["ListUsers"] = testutil.MockUsersResponse
+
+	server, lastVars := testutil.MockServerCapture(t, handlers)
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewListCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	// "Test User" will be resolved via ResolveUser → ListUsers mock → "user-123"
+	cmd.SetArgs([]string{"--actor=Test User"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	vars := lastVars()
+	if vars == nil {
+		t.Fatal("no variables captured")
+	}
+	filter, ok := vars["filter"].(map[string]any)
+	if !ok {
+		t.Fatalf("variables[filter] = %T, want map", vars["filter"])
+	}
+	actor, ok := filter["actor"].(map[string]any)
+	if !ok {
+		t.Fatalf("filter[actor] = %T, want map", filter["actor"])
+	}
+	id, ok := actor["id"].(map[string]any)
+	if !ok {
+		t.Fatalf("actor[id] = %T, want map", actor["id"])
+	}
+	eq, ok := id["eq"].(string)
+	if !ok {
+		t.Fatalf("id[eq] = %T, want string", id["eq"])
+	}
+	if eq != "user-123" {
+		t.Errorf("actor.id.eq = %q, want %q", eq, "user-123")
+	}
+}
+
+func TestRunListTypeFilterVariables(t *testing.T) {
+	server, lastVars := testutil.MockServerCapture(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewListCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--type=issue.create"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	vars := lastVars()
+	if vars == nil {
+		t.Fatal("no variables captured")
+	}
+	filter, ok := vars["filter"].(map[string]any)
+	if !ok {
+		t.Fatalf("variables[filter] = %T, want map", vars["filter"])
+	}
+	typ, ok := filter["type"].(map[string]any)
+	if !ok {
+		t.Fatalf("filter[type] = %T, want map", filter["type"])
+	}
+	if eq, _ := typ["eq"].(string); !strings.EqualFold(eq, "issue.create") {
+		t.Errorf("type.eq = %q, want issue.create", eq)
+	}
 }
 
 func TestRunTypes(t *testing.T) {

--- a/cmd/linear/commands/audit/audit_test.go
+++ b/cmd/linear/commands/audit/audit_test.go
@@ -1,0 +1,133 @@
+package audit
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/testutil"
+)
+
+func TestNewAuditCommand(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewAuditCommand(factory)
+	if cmd.Use != "audit" {
+		t.Errorf("Use = %q, want %q", cmd.Use, "audit")
+	}
+	if len(cmd.Commands()) != 2 {
+		t.Errorf("Expected 2 subcommands, got %d", len(cmd.Commands()))
+	}
+}
+
+func TestNewListCommand(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewListCommand(factory)
+	if cmd.Use != "list" {
+		t.Errorf("Use = %q, want %q", cmd.Use, "list")
+	}
+
+	expectedFlags := []string{"type", "actor", "ip", "created-after", "created-before", "limit"}
+	for _, flag := range expectedFlags {
+		if cmd.Flags().Lookup(flag) == nil {
+			t.Errorf("Expected flag %q not found", flag)
+		}
+	}
+}
+
+func TestRunList(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	t.Run("list json output", func(t *testing.T) {
+		cmd := NewListCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("Output should be valid JSON: %v", err)
+		}
+		if _, ok := result["nodes"]; !ok {
+			t.Error("Expected 'nodes' field in output")
+		}
+	})
+
+	t.Run("list with type filter", func(t *testing.T) {
+		cmd := NewListCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"--type=issue.create"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+
+	t.Run("list with created-after filter", func(t *testing.T) {
+		cmd := NewListCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"--created-after=7d"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+
+	t.Run("list with created-before filter", func(t *testing.T) {
+		cmd := NewListCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"--created-before=2025-12-31"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+
+	t.Run("list with limit", func(t *testing.T) {
+		cmd := NewListCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"--limit=10"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+}
+
+func TestRunTypes(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewTypesCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var result []any
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("Output should be valid JSON array: %v", err)
+	}
+	if len(result) == 0 {
+		t.Error("Expected non-empty types list")
+	}
+}

--- a/cmd/linear/commands/audit/audit_test.go
+++ b/cmd/linear/commands/audit/audit_test.go
@@ -225,8 +225,36 @@ func TestRunListTypeFilterVariables(t *testing.T) {
 	if !ok {
 		t.Fatalf("filter[type] = %T, want map", filter["type"])
 	}
-	if eq, _ := typ["eq"].(string); !strings.EqualFold(eq, "issue.create") {
+	if eq, _ := typ["eq"].(string); eq != "issue.create" {
 		t.Errorf("type.eq = %q, want issue.create", eq)
+	}
+}
+
+func TestRunListTypeNormalized(t *testing.T) {
+	server, lastVars := testutil.MockServerCapture(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewListCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--type=Issue.Create"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	vars := lastVars()
+	filter, ok := vars["filter"].(map[string]any)
+	if !ok {
+		t.Fatalf("variables[filter] = %T, want map", vars["filter"])
+	}
+	typ, ok := filter["type"].(map[string]any)
+	if !ok {
+		t.Fatalf("filter[type] = %T, want map", filter["type"])
+	}
+	if eq, _ := typ["eq"].(string); eq != "issue.create" {
+		t.Errorf("type.eq = %q, want %q (should be lowercased)", eq, "issue.create")
 	}
 }
 
@@ -372,7 +400,7 @@ func TestRunListInvertedDateRange(t *testing.T) {
 	cmd := NewListCommand(factory)
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
-	// after=7d is ~April 2026, before=30d is ~April 2026 but earlier — inverted
+	// after=7d (~7 days ago) is more recent than before=30d (~30 days ago) — range is inverted
 	cmd.SetArgs([]string{"--created-after=7d", "--created-before=30d"})
 
 	err := cmd.Execute()
@@ -463,11 +491,19 @@ func TestRunTypes(t *testing.T) {
 		t.Fatalf("Execute() error = %v", err)
 	}
 
-	var result []any
+	var result []map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
 		t.Fatalf("Output should be valid JSON array: %v", err)
 	}
 	if len(result) == 0 {
 		t.Error("Expected non-empty types list")
+	}
+	for i, entry := range result {
+		if _, ok := entry["type"].(string); !ok {
+			t.Errorf("result[%d] missing string 'type' field", i)
+		}
+		if _, ok := entry["description"].(string); !ok {
+			t.Errorf("result[%d] missing string 'description' field", i)
+		}
 	}
 }

--- a/cmd/linear/commands/audit/audit_test.go
+++ b/cmd/linear/commands/audit/audit_test.go
@@ -34,7 +34,7 @@ func TestNewListCommand(t *testing.T) {
 		t.Errorf("Use = %q, want %q", cmd.Use, "list")
 	}
 
-	expectedFlags := []string{"type", "actor", "ip", "created-after", "created-before", "limit"}
+	expectedFlags := []string{"type", "actor", "ip", "country-code", "created-after", "created-before", "limit"}
 	for _, flag := range expectedFlags {
 		if cmd.Flags().Lookup(flag) == nil {
 			t.Errorf("Expected flag %q not found", flag)
@@ -227,6 +227,205 @@ func TestRunListTypeFilterVariables(t *testing.T) {
 	}
 	if eq, _ := typ["eq"].(string); !strings.EqualFold(eq, "issue.create") {
 		t.Errorf("type.eq = %q, want issue.create", eq)
+	}
+}
+
+func TestRunListIPFilterVariables(t *testing.T) {
+	server, lastVars := testutil.MockServerCapture(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewListCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--ip=1.2.3.4"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	vars := lastVars()
+	if vars == nil {
+		t.Fatal("no variables captured")
+	}
+	filter, ok := vars["filter"].(map[string]any)
+	if !ok {
+		t.Fatalf("variables[filter] = %T, want map", vars["filter"])
+	}
+	ip, ok := filter["ip"].(map[string]any)
+	if !ok {
+		t.Fatalf("filter[ip] = %T, want map", filter["ip"])
+	}
+	if eq, _ := ip["eq"].(string); eq != "1.2.3.4" {
+		t.Errorf("ip.eq = %q, want %q", eq, "1.2.3.4")
+	}
+}
+
+func TestRunListCountryCodeFilterVariables(t *testing.T) {
+	server, lastVars := testutil.MockServerCapture(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewListCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--country-code=US"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	vars := lastVars()
+	if vars == nil {
+		t.Fatal("no variables captured")
+	}
+	filter, ok := vars["filter"].(map[string]any)
+	if !ok {
+		t.Fatalf("variables[filter] = %T, want map", vars["filter"])
+	}
+	cc, ok := filter["countryCode"].(map[string]any)
+	if !ok {
+		t.Fatalf("filter[countryCode] = %T, want map", filter["countryCode"])
+	}
+	if eq, _ := cc["eq"].(string); eq != "US" {
+		t.Errorf("countryCode.eq = %q, want %q", eq, "US")
+	}
+}
+
+func TestRunListCreatedBeforeVariables(t *testing.T) {
+	server, lastVars := testutil.MockServerCapture(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewListCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--created-before=2025-12-31"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	vars := lastVars()
+	if vars == nil {
+		t.Fatal("no variables captured")
+	}
+	filter, ok := vars["filter"].(map[string]any)
+	if !ok {
+		t.Fatalf("variables[filter] = %T, want map", vars["filter"])
+	}
+	createdAt, ok := filter["createdAt"].(map[string]any)
+	if !ok {
+		t.Fatalf("filter[createdAt] = %T, want map", filter["createdAt"])
+	}
+	lte, ok := createdAt["lte"].(string)
+	if !ok {
+		t.Fatalf("createdAt[lte] = %T, want string", createdAt["lte"])
+	}
+	if _, err := time.Parse(time.RFC3339, lte); err != nil {
+		t.Errorf("createdAt.lte %q is not valid RFC3339: %v", lte, err)
+	}
+	if createdAt["gte"] != nil {
+		t.Errorf("createdAt.gte should be absent, got %v", createdAt["gte"])
+	}
+}
+
+func TestRunListCreatedDateRange(t *testing.T) {
+	server, lastVars := testutil.MockServerCapture(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewListCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--created-after=7d", "--created-before=2025-12-31"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	vars := lastVars()
+	if vars == nil {
+		t.Fatal("no variables captured")
+	}
+	filter, ok := vars["filter"].(map[string]any)
+	if !ok {
+		t.Fatalf("variables[filter] = %T, want map", vars["filter"])
+	}
+	createdAt, ok := filter["createdAt"].(map[string]any)
+	if !ok {
+		t.Fatalf("filter[createdAt] = %T, want map", filter["createdAt"])
+	}
+	if _, ok := createdAt["gte"].(string); !ok {
+		t.Errorf("createdAt.gte missing or not string, got %T", createdAt["gte"])
+	}
+	if _, ok := createdAt["lte"].(string); !ok {
+		t.Errorf("createdAt.lte missing or not string, got %T", createdAt["lte"])
+	}
+}
+
+func TestRunListInvalidCreatedAfter(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewListCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--created-after=not-a-date"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() expected error for invalid --created-after, got nil")
+	}
+	if !strings.Contains(err.Error(), "created-after") {
+		t.Errorf("error %q should mention 'created-after'", err.Error())
+	}
+}
+
+func TestRunListActorNotFound(t *testing.T) {
+	handlers := defaultHandlers()
+	// Return empty users list so resolver fails to find the actor
+	handlers["ListUsers"] = `{"data":{"users":{"nodes":[],"pageInfo":{"hasNextPage":false}}}}`
+
+	server := testutil.MockServer(t, handlers)
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewListCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--actor=nobody"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("Execute() expected error when actor not found, got nil")
+	}
+}
+
+func TestRunListAfterCursorForwarded(t *testing.T) {
+	server, lastVars := testutil.MockServerCapture(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewListCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--after=cursor-abc123"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	vars := lastVars()
+	if vars == nil {
+		t.Fatal("no variables captured")
+	}
+	after, ok := vars["after"].(string)
+	if !ok {
+		t.Fatalf("vars[after] = %T, want string", vars["after"])
+	}
+	if after != "cursor-abc123" {
+		t.Errorf("after = %q, want %q", after, "cursor-abc123")
 	}
 }
 

--- a/cmd/linear/commands/audit/helpers_test.go
+++ b/cmd/linear/commands/audit/helpers_test.go
@@ -1,0 +1,37 @@
+package audit
+
+const (
+	mockAuditEntriesResponse = `{
+		"data": {
+			"auditEntries": {
+				"nodes": [
+					{
+						"id": "ae-123",
+						"type": "issue.create",
+						"createdAt": "2024-01-01T00:00:00.000Z",
+						"ip": "192.168.1.1",
+						"actor": {"id": "user-123", "name": "Test User"}
+					}
+				],
+				"pageInfo": {"hasNextPage": false}
+			}
+		}
+	}`
+
+	mockAuditEntryTypesResponse = `{
+		"data": {
+			"auditEntryTypes": [
+				{"type": "issue.create", "description": "Issue created"},
+				{"type": "issue.update", "description": "Issue updated"},
+				{"type": "issue.delete", "description": "Issue deleted"}
+			]
+		}
+	}`
+)
+
+func defaultHandlers() map[string]string {
+	return map[string]string{
+		"ListAuditEntries":    mockAuditEntriesResponse,
+		"ListAuditEntryTypes": mockAuditEntryTypesResponse,
+	}
+}

--- a/cmd/linear/commands/audit/helpers_test.go
+++ b/cmd/linear/commands/audit/helpers_test.go
@@ -10,7 +10,7 @@ const (
 						"type": "issue.create",
 						"createdAt": "2024-01-01T00:00:00.000Z",
 						"ip": "192.168.1.1",
-						"actor": {"id": "user-123", "name": "Test User"}
+						"actor": {"id": "user-123", "name": "Test User", "email": "test@example.com"}
 					}
 				],
 				"pageInfo": {"hasNextPage": false}

--- a/cmd/linear/commands/audit/list.go
+++ b/cmd/linear/commands/audit/list.go
@@ -23,7 +23,7 @@ func NewListCommand(clientFactory cli.ClientFactory) *cobra.Command {
 		Short: "List audit log entries",
 		Long: `List audit log entries with optional filtering. Requires Admin or Owner role.
 
-Filters: --type (entry type), --actor (user name, email, or ID), --ip, --created-after, --created-before
+Filters: --type (entry type), --actor (user name, email, or ID), --ip, --country-code, --created-after, --created-before
 Date filters accept ISO8601, relative durations ('7d', '2w'), or 'yesterday'. Comparisons are inclusive.
 
 Example: go-linear audit list --type=issue.create --limit=20
@@ -44,6 +44,7 @@ Related: audit types`,
 	cmd.Flags().String("type", "", "Filter by audit entry type (see: audit types)")
 	cmd.Flags().String("actor", "", "Filter by actor (name, email, or user ID)")
 	cmd.Flags().String("ip", "", "Filter by IP address")
+	cmd.Flags().String("country-code", "", "Filter by country code (e.g. US, DE)")
 	cmd.Flags().String("created-after", "", "Created after date, inclusive (ISO8601, 'yesterday', '7d')")
 	cmd.Flags().String("created-before", "", "Created before date, inclusive (ISO8601, 'yesterday', '7d')")
 	paginationFlags.Bind(cmd, 50)
@@ -65,10 +66,11 @@ func runList(cmd *cobra.Command, client *linear.Client, paginationFlags *cli.Pag
 	typeFlag, _ := cmd.Flags().GetString("type")
 	actorFlag, _ := cmd.Flags().GetString("actor")
 	ipFlag, _ := cmd.Flags().GetString("ip")
+	countryCodeFlag, _ := cmd.Flags().GetString("country-code")
 	createdAfter, _ := cmd.Flags().GetString("created-after")
 	createdBefore, _ := cmd.Flags().GetString("created-before")
 
-	if typeFlag != "" || actorFlag != "" || ipFlag != "" || createdAfter != "" || createdBefore != "" {
+	if typeFlag != "" || actorFlag != "" || ipFlag != "" || countryCodeFlag != "" || createdAfter != "" || createdBefore != "" {
 		filter = &intgraphql.AuditEntryFilter{}
 
 		if typeFlag != "" {
@@ -86,6 +88,9 @@ func runList(cmd *cobra.Command, client *linear.Client, paginationFlags *cli.Pag
 		}
 		if ipFlag != "" {
 			filter.IP = &intgraphql.StringComparator{Eq: &ipFlag}
+		}
+		if countryCodeFlag != "" {
+			filter.CountryCode = &intgraphql.StringComparator{Eq: &countryCodeFlag}
 		}
 
 		parser := dateparser.New()

--- a/cmd/linear/commands/audit/list.go
+++ b/cmd/linear/commands/audit/list.go
@@ -1,0 +1,114 @@
+package audit
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/dateparser"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewListCommand creates the audit list command.
+func NewListCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	paginationFlags := &cli.PaginationFlags{}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List audit log entries",
+		Long: `List audit log entries with optional filtering.
+
+Filters: --type (entry type), --actor (user ID), --ip, --created-after, --created-before
+
+Example: go-linear audit list --type=issue.create --limit=20
+Example: go-linear audit list --created-after=7d
+
+Related: audit_types`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runList(cmd, client, paginationFlags)
+		},
+	}
+
+	cmd.Flags().String("type", "", "Filter by audit entry type")
+	cmd.Flags().String("actor", "", "Filter by actor user ID")
+	cmd.Flags().String("ip", "", "Filter by IP address")
+	cmd.Flags().String("created-after", "", "Created after date (ISO8601, 'yesterday', '7d')")
+	cmd.Flags().String("created-before", "", "Created before date")
+	paginationFlags.Bind(cmd, 50)
+
+	return cmd
+}
+
+func runList(cmd *cobra.Command, client *linear.Client, paginationFlags *cli.PaginationFlags) error {
+	ctx := cmd.Context()
+
+	first := paginationFlags.LimitPtr()
+	var afterPtr *string
+	if paginationFlags.After != "" {
+		afterPtr = &paginationFlags.After
+	}
+
+	// Build filter
+	var filter *intgraphql.AuditEntryFilter
+	typeFlag, _ := cmd.Flags().GetString("type")
+	actorFlag, _ := cmd.Flags().GetString("actor")
+	ipFlag, _ := cmd.Flags().GetString("ip")
+	createdAfter, _ := cmd.Flags().GetString("created-after")
+	createdBefore, _ := cmd.Flags().GetString("created-before")
+
+	if typeFlag != "" || actorFlag != "" || ipFlag != "" || createdAfter != "" || createdBefore != "" {
+		filter = &intgraphql.AuditEntryFilter{}
+
+		if typeFlag != "" {
+			filter.Type = &intgraphql.StringComparator{Eq: &typeFlag}
+		}
+		if actorFlag != "" {
+			filter.Actor = &intgraphql.NullableUserFilter{
+				ID: &intgraphql.IDComparator{Eq: &actorFlag},
+			}
+		}
+		if ipFlag != "" {
+			filter.IP = &intgraphql.StringComparator{Eq: &ipFlag}
+		}
+
+		parser := dateparser.New()
+		if createdAfter != "" {
+			t, err := parser.Parse(createdAfter)
+			if err != nil {
+				return fmt.Errorf("invalid --created-after: %w", err)
+			}
+			if filter.CreatedAt == nil {
+				filter.CreatedAt = &intgraphql.DateComparator{}
+			}
+			s := t.Format("2006-01-02T15:04:05.000Z")
+			filter.CreatedAt.Gte = &s
+		}
+		if createdBefore != "" {
+			t, err := parser.Parse(createdBefore)
+			if err != nil {
+				return fmt.Errorf("invalid --created-before: %w", err)
+			}
+			if filter.CreatedAt == nil {
+				filter.CreatedAt = &intgraphql.DateComparator{}
+			}
+			s := t.Format("2006-01-02T15:04:05.000Z")
+			filter.CreatedAt.Lte = &s
+		}
+	}
+
+	entries, err := client.AuditEntries(ctx, first, afterPtr, filter)
+	if err != nil {
+		return fmt.Errorf("failed to list audit entries: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), entries, true)
+}

--- a/cmd/linear/commands/audit/list.go
+++ b/cmd/linear/commands/audit/list.go
@@ -116,6 +116,11 @@ func runList(cmd *cobra.Command, client *linear.Client, paginationFlags *cli.Pag
 			s := t.UTC().Format(time.RFC3339)
 			filter.CreatedAt.Lte = &s
 		}
+		if filter.CreatedAt != nil && filter.CreatedAt.Gte != nil && filter.CreatedAt.Lte != nil {
+			if *filter.CreatedAt.Gte > *filter.CreatedAt.Lte {
+				return fmt.Errorf("--created-after must be earlier than --created-before")
+			}
+		}
 	}
 
 	entries, err := client.AuditEntries(ctx, first, afterPtr, filter)

--- a/cmd/linear/commands/audit/list.go
+++ b/cmd/linear/commands/audit/list.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -26,10 +27,12 @@ func NewListCommand(clientFactory cli.ClientFactory) *cobra.Command {
 Filters: --type (entry type), --actor (user name, email, or ID), --ip, --country-code, --created-after, --created-before
 Date filters accept ISO8601, relative durations ('7d', '2w'), or 'yesterday'. Comparisons are inclusive.
 
+Note: output may include sensitive values in metadata and requestInformation fields (e.g. session tokens, headers).
+
 Example: go-linear audit list --type=issue.create --limit=20
 Example: go-linear audit list --actor=jane@example.com --created-after=7d
 
-Related: audit types`,
+Related: audit_types`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := clientFactory()
 			if err != nil {
@@ -74,7 +77,8 @@ func runList(cmd *cobra.Command, client *linear.Client, paginationFlags *cli.Pag
 		filter = &intgraphql.AuditEntryFilter{}
 
 		if typeFlag != "" {
-			filter.Type = &intgraphql.StringComparator{Eq: &typeFlag}
+			normalized := strings.ToLower(typeFlag)
+			filter.Type = &intgraphql.StringComparator{Eq: &normalized}
 		}
 		if actorFlag != "" {
 			res := resolver.New(client)

--- a/cmd/linear/commands/audit/list.go
+++ b/cmd/linear/commands/audit/list.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/chainguard-sandbox/go-linear/v2/internal/dateparser"
 	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
 	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/resolver"
 	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
 )
 
@@ -19,14 +21,15 @@ func NewListCommand(clientFactory cli.ClientFactory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List audit log entries",
-		Long: `List audit log entries with optional filtering.
+		Long: `List audit log entries with optional filtering. Requires Admin or Owner role.
 
-Filters: --type (entry type), --actor (user ID), --ip, --created-after, --created-before
+Filters: --type (entry type), --actor (user name, email, or ID), --ip, --created-after, --created-before
+Date filters accept ISO8601, relative durations ('7d', '2w'), or 'yesterday'. Comparisons are inclusive.
 
 Example: go-linear audit list --type=issue.create --limit=20
-Example: go-linear audit list --created-after=7d
+Example: go-linear audit list --actor=jane@example.com --created-after=7d
 
-Related: audit_types`,
+Related: audit types`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := clientFactory()
 			if err != nil {
@@ -38,11 +41,11 @@ Related: audit_types`,
 		},
 	}
 
-	cmd.Flags().String("type", "", "Filter by audit entry type")
-	cmd.Flags().String("actor", "", "Filter by actor user ID")
+	cmd.Flags().String("type", "", "Filter by audit entry type (see: audit types)")
+	cmd.Flags().String("actor", "", "Filter by actor (name, email, or user ID)")
 	cmd.Flags().String("ip", "", "Filter by IP address")
-	cmd.Flags().String("created-after", "", "Created after date (ISO8601, 'yesterday', '7d')")
-	cmd.Flags().String("created-before", "", "Created before date")
+	cmd.Flags().String("created-after", "", "Created after date, inclusive (ISO8601, 'yesterday', '7d')")
+	cmd.Flags().String("created-before", "", "Created before date, inclusive (ISO8601, 'yesterday', '7d')")
 	paginationFlags.Bind(cmd, 50)
 
 	return cmd
@@ -72,8 +75,13 @@ func runList(cmd *cobra.Command, client *linear.Client, paginationFlags *cli.Pag
 			filter.Type = &intgraphql.StringComparator{Eq: &typeFlag}
 		}
 		if actorFlag != "" {
+			res := resolver.New(client)
+			actorID, err := res.ResolveUser(ctx, actorFlag)
+			if err != nil {
+				return fmt.Errorf("failed to resolve --actor: %w", err)
+			}
 			filter.Actor = &intgraphql.NullableUserFilter{
-				ID: &intgraphql.IDComparator{Eq: &actorFlag},
+				ID: &intgraphql.IDComparator{Eq: &actorID},
 			}
 		}
 		if ipFlag != "" {
@@ -89,7 +97,7 @@ func runList(cmd *cobra.Command, client *linear.Client, paginationFlags *cli.Pag
 			if filter.CreatedAt == nil {
 				filter.CreatedAt = &intgraphql.DateComparator{}
 			}
-			s := t.Format("2006-01-02T15:04:05.000Z")
+			s := t.UTC().Format(time.RFC3339)
 			filter.CreatedAt.Gte = &s
 		}
 		if createdBefore != "" {
@@ -100,7 +108,7 @@ func runList(cmd *cobra.Command, client *linear.Client, paginationFlags *cli.Pag
 			if filter.CreatedAt == nil {
 				filter.CreatedAt = &intgraphql.DateComparator{}
 			}
-			s := t.Format("2006-01-02T15:04:05.000Z")
+			s := t.UTC().Format(time.RFC3339)
 			filter.CreatedAt.Lte = &s
 		}
 	}

--- a/cmd/linear/commands/audit/types.go
+++ b/cmd/linear/commands/audit/types.go
@@ -1,0 +1,48 @@
+package audit
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewTypesCommand creates the audit types command.
+func NewTypesCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "types",
+		Short: "List available audit entry types",
+		Long: `List all available audit entry types with descriptions.
+
+Use this to discover valid values for the --type filter in audit list.
+
+Example: go-linear audit types
+
+Related: audit_list`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runTypes(cmd, client)
+		},
+	}
+
+	return cmd
+}
+
+func runTypes(cmd *cobra.Command, client *linear.Client) error {
+	ctx := cmd.Context()
+
+	types, err := client.AuditEntryTypes(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list audit entry types: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), types, true)
+}

--- a/cmd/linear/commands/audit/types.go
+++ b/cmd/linear/commands/audit/types.go
@@ -21,7 +21,7 @@ Use this to discover valid values for the --type filter in audit list. Requires 
 
 Example: go-linear audit types
 
-Related: audit list`,
+Related: audit_list`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := clientFactory()
 			if err != nil {

--- a/cmd/linear/commands/audit/types.go
+++ b/cmd/linear/commands/audit/types.go
@@ -17,11 +17,11 @@ func NewTypesCommand(clientFactory cli.ClientFactory) *cobra.Command {
 		Short: "List available audit entry types",
 		Long: `List all available audit entry types with descriptions.
 
-Use this to discover valid values for the --type filter in audit list.
+Use this to discover valid values for the --type filter in audit list. Requires Admin or Owner role.
 
 Example: go-linear audit types
 
-Related: audit_list`,
+Related: audit list`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := clientFactory()
 			if err != nil {

--- a/cmd/linear/commands/root.go
+++ b/cmd/linear/commands/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chainguard-dev/clog"
 	"github.com/spf13/cobra"
 
+	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/audit"
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/attachment"
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/comment"
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/cycle"
@@ -297,6 +298,7 @@ Environment Variables:
 	}
 
 	// Add subcommands (ordered alphabetically)
+	rootCmd.AddCommand(audit.NewAuditCommand(getClient))
 	rootCmd.AddCommand(attachment.NewAttachmentCommand(getClient))
 	rootCmd.AddCommand(comment.NewCommentCommand(getClient))
 	rootCmd.AddCommand(cycle.NewCycleCommand(getClient))

--- a/cmd/linear/commands/root.go
+++ b/cmd/linear/commands/root.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/chainguard-dev/clog"
+	"github.com/spf13/cobra"
+
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/attachment"
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/audit"
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/comment"
@@ -33,7 +35,6 @@ import (
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/user"
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/viewer"
 	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
-	"github.com/spf13/cobra"
 )
 
 // clientConfig holds parsed configuration from environment variables.

--- a/cmd/linear/commands/root.go
+++ b/cmd/linear/commands/root.go
@@ -12,10 +12,8 @@ import (
 	"time"
 
 	"github.com/chainguard-dev/clog"
-	"github.com/spf13/cobra"
-
-	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/audit"
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/attachment"
+	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/audit"
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/comment"
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/cycle"
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/document"
@@ -35,6 +33,7 @@ import (
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/user"
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands/viewer"
 	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+	"github.com/spf13/cobra"
 )
 
 // clientConfig holds parsed configuration from environment variables.

--- a/cmd/linear/commands/root.go
+++ b/cmd/linear/commands/root.go
@@ -298,8 +298,8 @@ Environment Variables:
 	}
 
 	// Add subcommands (ordered alphabetically)
-	rootCmd.AddCommand(audit.NewAuditCommand(getClient))
 	rootCmd.AddCommand(attachment.NewAttachmentCommand(getClient))
+	rootCmd.AddCommand(audit.NewAuditCommand(getClient))
 	rootCmd.AddCommand(comment.NewCommentCommand(getClient))
 	rootCmd.AddCommand(cycle.NewCycleCommand(getClient))
 	rootCmd.AddCommand(document.NewDocumentCommand(getClient))

--- a/internal/graphql/client.go
+++ b/internal/graphql/client.go
@@ -13,6 +13,8 @@ type LinearGraphQLClient interface {
 	GetAttachment(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*GetAttachment, error)
 	ListAttachments(ctx context.Context, first *int64, after *string, interceptors ...clientv2.RequestInterceptor) (*ListAttachments, error)
 	ListAttachmentsFiltered(ctx context.Context, first *int64, after *string, filter *AttachmentFilter, interceptors ...clientv2.RequestInterceptor) (*ListAttachmentsFiltered, error)
+	ListAuditEntries(ctx context.Context, first *int64, after *string, filter *AuditEntryFilter, interceptors ...clientv2.RequestInterceptor) (*ListAuditEntries, error)
+	ListAuditEntryTypes(ctx context.Context, interceptors ...clientv2.RequestInterceptor) (*ListAuditEntryTypes, error)
 	BatchUpdateIssues(ctx context.Context, ids []string, input IssueUpdateInput, interceptors ...clientv2.RequestInterceptor) (*BatchUpdateIssues, error)
 	GetComment(ctx context.Context, id string, childrenLimit *int64, childrenAfter *string, interceptors ...clientv2.RequestInterceptor) (*GetComment, error)
 	ListComments(ctx context.Context, first *int64, after *string, interceptors ...clientv2.RequestInterceptor) (*ListComments, error)
@@ -392,6 +394,159 @@ func (t *ListAttachmentsFiltered_Attachments) GetPageInfo() *ListAttachmentsFilt
 		t = &ListAttachmentsFiltered_Attachments{}
 	}
 	return &t.PageInfo
+}
+
+type ListAuditEntries_AuditEntries_Nodes_Actor struct {
+	Email string "json:\"email\" graphql:\"email\""
+	ID    string "json:\"id\" graphql:\"id\""
+	Name  string "json:\"name\" graphql:\"name\""
+}
+
+func (t *ListAuditEntries_AuditEntries_Nodes_Actor) GetEmail() string {
+	if t == nil {
+		t = &ListAuditEntries_AuditEntries_Nodes_Actor{}
+	}
+	return t.Email
+}
+func (t *ListAuditEntries_AuditEntries_Nodes_Actor) GetID() string {
+	if t == nil {
+		t = &ListAuditEntries_AuditEntries_Nodes_Actor{}
+	}
+	return t.ID
+}
+func (t *ListAuditEntries_AuditEntries_Nodes_Actor) GetName() string {
+	if t == nil {
+		t = &ListAuditEntries_AuditEntries_Nodes_Actor{}
+	}
+	return t.Name
+}
+
+type ListAuditEntries_AuditEntries_Nodes struct {
+	Actor              *ListAuditEntries_AuditEntries_Nodes_Actor "json:\"actor,omitempty\" graphql:\"actor\""
+	ActorID            *string                                    "json:\"actorId,omitempty\" graphql:\"actorId\""
+	CountryCode        *string                                    "json:\"countryCode,omitempty\" graphql:\"countryCode\""
+	CreatedAt          time.Time                                  "json:\"createdAt\" graphql:\"createdAt\""
+	ID                 string                                     "json:\"id\" graphql:\"id\""
+	IP                 *string                                    "json:\"ip,omitempty\" graphql:\"ip\""
+	Metadata           map[string]any                             "json:\"metadata,omitempty\" graphql:\"metadata\""
+	RequestInformation map[string]any                             "json:\"requestInformation,omitempty\" graphql:\"requestInformation\""
+	Type               string                                     "json:\"type\" graphql:\"type\""
+	UpdatedAt          time.Time                                  "json:\"updatedAt\" graphql:\"updatedAt\""
+}
+
+func (t *ListAuditEntries_AuditEntries_Nodes) GetActor() *ListAuditEntries_AuditEntries_Nodes_Actor {
+	if t == nil {
+		t = &ListAuditEntries_AuditEntries_Nodes{}
+	}
+	return t.Actor
+}
+func (t *ListAuditEntries_AuditEntries_Nodes) GetActorID() *string {
+	if t == nil {
+		t = &ListAuditEntries_AuditEntries_Nodes{}
+	}
+	return t.ActorID
+}
+func (t *ListAuditEntries_AuditEntries_Nodes) GetCountryCode() *string {
+	if t == nil {
+		t = &ListAuditEntries_AuditEntries_Nodes{}
+	}
+	return t.CountryCode
+}
+func (t *ListAuditEntries_AuditEntries_Nodes) GetCreatedAt() *time.Time {
+	if t == nil {
+		t = &ListAuditEntries_AuditEntries_Nodes{}
+	}
+	return &t.CreatedAt
+}
+func (t *ListAuditEntries_AuditEntries_Nodes) GetID() string {
+	if t == nil {
+		t = &ListAuditEntries_AuditEntries_Nodes{}
+	}
+	return t.ID
+}
+func (t *ListAuditEntries_AuditEntries_Nodes) GetIP() *string {
+	if t == nil {
+		t = &ListAuditEntries_AuditEntries_Nodes{}
+	}
+	return t.IP
+}
+func (t *ListAuditEntries_AuditEntries_Nodes) GetMetadata() map[string]any {
+	if t == nil {
+		t = &ListAuditEntries_AuditEntries_Nodes{}
+	}
+	return t.Metadata
+}
+func (t *ListAuditEntries_AuditEntries_Nodes) GetRequestInformation() map[string]any {
+	if t == nil {
+		t = &ListAuditEntries_AuditEntries_Nodes{}
+	}
+	return t.RequestInformation
+}
+func (t *ListAuditEntries_AuditEntries_Nodes) GetType() string {
+	if t == nil {
+		t = &ListAuditEntries_AuditEntries_Nodes{}
+	}
+	return t.Type
+}
+func (t *ListAuditEntries_AuditEntries_Nodes) GetUpdatedAt() *time.Time {
+	if t == nil {
+		t = &ListAuditEntries_AuditEntries_Nodes{}
+	}
+	return &t.UpdatedAt
+}
+
+type ListAuditEntries_AuditEntries_PageInfo struct {
+	EndCursor   *string "json:\"endCursor,omitempty\" graphql:\"endCursor\""
+	HasNextPage bool    "json:\"hasNextPage\" graphql:\"hasNextPage\""
+}
+
+func (t *ListAuditEntries_AuditEntries_PageInfo) GetEndCursor() *string {
+	if t == nil {
+		t = &ListAuditEntries_AuditEntries_PageInfo{}
+	}
+	return t.EndCursor
+}
+func (t *ListAuditEntries_AuditEntries_PageInfo) GetHasNextPage() bool {
+	if t == nil {
+		t = &ListAuditEntries_AuditEntries_PageInfo{}
+	}
+	return t.HasNextPage
+}
+
+type ListAuditEntries_AuditEntries struct {
+	Nodes    []*ListAuditEntries_AuditEntries_Nodes "json:\"nodes\" graphql:\"nodes\""
+	PageInfo ListAuditEntries_AuditEntries_PageInfo "json:\"pageInfo\" graphql:\"pageInfo\""
+}
+
+func (t *ListAuditEntries_AuditEntries) GetNodes() []*ListAuditEntries_AuditEntries_Nodes {
+	if t == nil {
+		t = &ListAuditEntries_AuditEntries{}
+	}
+	return t.Nodes
+}
+func (t *ListAuditEntries_AuditEntries) GetPageInfo() *ListAuditEntries_AuditEntries_PageInfo {
+	if t == nil {
+		t = &ListAuditEntries_AuditEntries{}
+	}
+	return &t.PageInfo
+}
+
+type ListAuditEntryTypes_AuditEntryTypes struct {
+	Description string "json:\"description\" graphql:\"description\""
+	Type        string "json:\"type\" graphql:\"type\""
+}
+
+func (t *ListAuditEntryTypes_AuditEntryTypes) GetDescription() string {
+	if t == nil {
+		t = &ListAuditEntryTypes_AuditEntryTypes{}
+	}
+	return t.Description
+}
+func (t *ListAuditEntryTypes_AuditEntryTypes) GetType() string {
+	if t == nil {
+		t = &ListAuditEntryTypes_AuditEntryTypes{}
+	}
+	return t.Type
 }
 
 type BatchUpdateIssues_IssueBatchUpdate_Issues_State struct {
@@ -9100,6 +9255,28 @@ func (t *ListAttachmentsFiltered) GetAttachments() *ListAttachmentsFiltered_Atta
 	return &t.Attachments
 }
 
+type ListAuditEntries struct {
+	AuditEntries ListAuditEntries_AuditEntries "json:\"auditEntries\" graphql:\"auditEntries\""
+}
+
+func (t *ListAuditEntries) GetAuditEntries() *ListAuditEntries_AuditEntries {
+	if t == nil {
+		t = &ListAuditEntries{}
+	}
+	return &t.AuditEntries
+}
+
+type ListAuditEntryTypes struct {
+	AuditEntryTypes []*ListAuditEntryTypes_AuditEntryTypes "json:\"auditEntryTypes\" graphql:\"auditEntryTypes\""
+}
+
+func (t *ListAuditEntryTypes) GetAuditEntryTypes() []*ListAuditEntryTypes_AuditEntryTypes {
+	if t == nil {
+		t = &ListAuditEntryTypes{}
+	}
+	return t.AuditEntryTypes
+}
+
 type BatchUpdateIssues struct {
 	IssueBatchUpdate BatchUpdateIssues_IssueBatchUpdate "json:\"issueBatchUpdate\" graphql:\"issueBatchUpdate\""
 }
@@ -10431,6 +10608,74 @@ func (c *Client) ListAttachmentsFiltered(ctx context.Context, first *int64, afte
 
 	var res ListAttachmentsFiltered
 	if err := c.Client.Post(ctx, "ListAttachmentsFiltered", ListAttachmentsFilteredDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const ListAuditEntriesDocument = `query ListAuditEntries ($first: Int, $after: String, $filter: AuditEntryFilter) {
+	auditEntries(first: $first, after: $after, filter: $filter) {
+		nodes {
+			id
+			type
+			actorId
+			ip
+			countryCode
+			createdAt
+			updatedAt
+			metadata
+			requestInformation
+			actor {
+				id
+				name
+				email
+			}
+		}
+		pageInfo {
+			hasNextPage
+			endCursor
+		}
+	}
+}
+`
+
+func (c *Client) ListAuditEntries(ctx context.Context, first *int64, after *string, filter *AuditEntryFilter, interceptors ...clientv2.RequestInterceptor) (*ListAuditEntries, error) {
+	vars := map[string]any{
+		"first":  first,
+		"after":  after,
+		"filter": filter,
+	}
+
+	var res ListAuditEntries
+	if err := c.Client.Post(ctx, "ListAuditEntries", ListAuditEntriesDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const ListAuditEntryTypesDocument = `query ListAuditEntryTypes {
+	auditEntryTypes {
+		type
+		description
+	}
+}
+`
+
+func (c *Client) ListAuditEntryTypes(ctx context.Context, interceptors ...clientv2.RequestInterceptor) (*ListAuditEntryTypes, error) {
+	vars := map[string]any{}
+
+	var res ListAuditEntryTypes
+	if err := c.Client.Post(ctx, "ListAuditEntryTypes", ListAuditEntryTypesDocument, &res, vars, interceptors...); err != nil {
 		if c.Client.ParseDataWhenErrors {
 			return &res, err
 		}
@@ -14342,6 +14587,8 @@ var DocumentOperationNames = map[string]string{
 	GetAttachmentDocument:                  "GetAttachment",
 	ListAttachmentsDocument:                "ListAttachments",
 	ListAttachmentsFilteredDocument:        "ListAttachmentsFiltered",
+	ListAuditEntriesDocument:               "ListAuditEntries",
+	ListAuditEntryTypesDocument:            "ListAuditEntryTypes",
 	BatchUpdateIssuesDocument:              "BatchUpdateIssues",
 	GetCommentDocument:                     "GetComment",
 	ListCommentsDocument:                   "ListComments",

--- a/internal/mcptools/mapper.go
+++ b/internal/mcptools/mapper.go
@@ -271,6 +271,10 @@ func initSpecialCases() map[string]string {
 		"linear_reaction_create": "ReactionPayload",
 		"linear_reaction_delete": "ArchivePayload",
 
+		// Audit log commands (non-standard naming: types is not a connection)
+		"linear_audit_list":  "AuditEntryConnection",
+		"linear_audit_types": "AuditEntryType",
+
 		// Organization view (single entity, not a list)
 		"linear_organization": "Organization",
 

--- a/internal/testutil/mock_server.go
+++ b/internal/testutil/mock_server.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
@@ -44,6 +45,52 @@ func MockServer(t *testing.T, handlers map[string]string) *httptest.Server {
 		t.Logf("No handler for operation: %s", reqBody.OperationName)
 		_, _ = w.Write([]byte(`{"data":{}}`))
 	}))
+}
+
+// MockServerCapture creates a test server that captures GraphQL variables from
+// each request. The returned function returns the variables from the most recent
+// request, for use in asserting that the correct fields were sent to the API.
+func MockServerCapture(t *testing.T, handlers map[string]string) (*httptest.Server, func() map[string]any) {
+	t.Helper()
+
+	var mu sync.Mutex
+	var last map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		var reqBody struct {
+			Query         string         `json:"query"`
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Logf("Failed to decode request: %v", err)
+			http.Error(w, "Bad request", http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		last = reqBody.Variables
+		mu.Unlock()
+
+		for key, response := range handlers {
+			if strings.EqualFold(key, reqBody.OperationName) {
+				_, _ = w.Write([]byte(response))
+				return
+			}
+		}
+
+		t.Logf("No handler for operation: %s", reqBody.OperationName)
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+
+	return server, func() map[string]any {
+		mu.Lock()
+		defer mu.Unlock()
+		return last
+	}
 }
 
 // TestFactory creates a cli.ClientFactory that connects to the given test server.

--- a/internal/testutil/mock_server.go
+++ b/internal/testutil/mock_server.go
@@ -13,12 +13,11 @@ import (
 	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
 )
 
-// MockServer creates a test server that handles Linear API queries.
-// Handlers are matched by GraphQL operation name (case-insensitive).
-func MockServer(t *testing.T, handlers map[string]string) *httptest.Server {
+// makeHandler builds an HTTP handler that dispatches GraphQL requests by
+// operation name and optionally calls onRequest with the decoded variables.
+func makeHandler(t *testing.T, handlers map[string]string, onRequest func(map[string]any)) http.Handler {
 	t.Helper()
-
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
 		var reqBody struct {
@@ -31,6 +30,10 @@ func MockServer(t *testing.T, handlers map[string]string) *httptest.Server {
 			t.Logf("Failed to decode request: %v", err)
 			http.Error(w, "Bad request", http.StatusBadRequest)
 			return
+		}
+
+		if onRequest != nil {
+			onRequest(reqBody.Variables)
 		}
 
 		// Match by operation name (case-insensitive)
@@ -44,7 +47,14 @@ func MockServer(t *testing.T, handlers map[string]string) *httptest.Server {
 		// No match - log and return empty response
 		t.Logf("No handler for operation: %s", reqBody.OperationName)
 		_, _ = w.Write([]byte(`{"data":{}}`))
-	}))
+	})
+}
+
+// MockServer creates a test server that handles Linear API queries.
+// Handlers are matched by GraphQL operation name (case-insensitive).
+func MockServer(t *testing.T, handlers map[string]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(makeHandler(t, handlers, nil))
 }
 
 // MockServerCapture creates a test server that captures GraphQL variables from
@@ -56,34 +66,10 @@ func MockServerCapture(t *testing.T, handlers map[string]string) (*httptest.Serv
 	var mu sync.Mutex
 	var last map[string]any
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		var reqBody struct {
-			Query         string         `json:"query"`
-			OperationName string         `json:"operationName"`
-			Variables     map[string]any `json:"variables"`
-		}
-
-		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
-			t.Logf("Failed to decode request: %v", err)
-			http.Error(w, "Bad request", http.StatusBadRequest)
-			return
-		}
-
+	server := httptest.NewServer(makeHandler(t, handlers, func(vars map[string]any) {
 		mu.Lock()
-		last = reqBody.Variables
+		last = vars
 		mu.Unlock()
-
-		for key, response := range handlers {
-			if strings.EqualFold(key, reqBody.OperationName) {
-				_, _ = w.Write([]byte(response))
-				return
-			}
-		}
-
-		t.Logf("No handler for operation: %s", reqBody.OperationName)
-		_, _ = w.Write([]byte(`{"data":{}}`))
 	}))
 
 	return server, func() map[string]any {

--- a/pkg/linear/client_audit.go
+++ b/pkg/linear/client_audit.go
@@ -17,7 +17,7 @@ import (
 //   - AuditEntries with nodes and pageInfo
 //   - error: Non-nil if query fails
 //
-// Permissions Required: Admin
+// Permissions Required: Admin or Owner
 //
 // Related: [AuditEntryTypes]
 func (c *Client) AuditEntries(ctx context.Context, first *int64, after *string, filter *intgraphql.AuditEntryFilter) (*intgraphql.ListAuditEntries_AuditEntries, error) {
@@ -34,7 +34,7 @@ func (c *Client) AuditEntries(ctx context.Context, first *int64, after *string, 
 //   - Array of AuditEntryType with type and description
 //   - error: Non-nil if query fails
 //
-// Permissions Required: Admin
+// Permissions Required: Admin or Owner
 //
 // Related: [AuditEntries]
 func (c *Client) AuditEntryTypes(ctx context.Context) ([]*intgraphql.ListAuditEntryTypes_AuditEntryTypes, error) {

--- a/pkg/linear/client_audit.go
+++ b/pkg/linear/client_audit.go
@@ -1,0 +1,46 @@
+package linear
+
+import (
+	"context"
+
+	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
+)
+
+// AuditEntries retrieves a paginated list of audit log entries.
+//
+// Parameters:
+//   - first: Number of entries to return (nil = server default ~50)
+//   - after: Cursor for pagination (nil = start from beginning)
+//   - filter: Optional filters (type, actor, ip, countryCode, createdAt)
+//
+// Returns:
+//   - AuditEntries with nodes and pageInfo
+//   - error: Non-nil if query fails
+//
+// Permissions Required: Admin
+//
+// Related: [AuditEntryTypes]
+func (c *Client) AuditEntries(ctx context.Context, first *int64, after *string, filter *intgraphql.AuditEntryFilter) (*intgraphql.ListAuditEntries_AuditEntries, error) {
+	resp, err := c.gqlClient.ListAuditEntries(ctx, first, after, filter)
+	if err != nil {
+		return nil, wrapGraphQLError("auditEntries query", err)
+	}
+	return &resp.AuditEntries, nil
+}
+
+// AuditEntryTypes retrieves the list of available audit entry types.
+//
+// Returns:
+//   - Array of AuditEntryType with type and description
+//   - error: Non-nil if query fails
+//
+// Permissions Required: Admin
+//
+// Related: [AuditEntries]
+func (c *Client) AuditEntryTypes(ctx context.Context) ([]*intgraphql.ListAuditEntryTypes_AuditEntryTypes, error) {
+	resp, err := c.gqlClient.ListAuditEntryTypes(ctx)
+	if err != nil {
+		return nil, wrapGraphQLError("auditEntryTypes query", err)
+	}
+	return resp.AuditEntryTypes, nil
+}

--- a/queries/audit.graphql
+++ b/queries/audit.graphql
@@ -1,0 +1,31 @@
+query ListAuditEntries($first: Int, $after: String, $filter: AuditEntryFilter) {
+  auditEntries(first: $first, after: $after, filter: $filter) {
+    nodes {
+      id
+      type
+      actorId
+      ip
+      countryCode
+      createdAt
+      updatedAt
+      metadata
+      requestInformation
+      actor {
+        id
+        name
+        email
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+
+query ListAuditEntryTypes {
+  auditEntryTypes {
+    type
+    description
+  }
+}


### PR DESCRIPTION
## Summary
- New audit command group with list and types subcommands
- Filters: --type, --actor, --ip, --created-after, --created-before

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)