### PR TITLE
feat(issue): add --estimate to issue update with float and clear support

### DIFF
--- a/cmd/linear/commands/issue/update.go
+++ b/cmd/linear/commands/issue/update.go
@@ -148,6 +148,7 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 	}
 
 	if cmd.Flags().Changed("estimate") {
+		// "none" is handled by runUpdateWithNullable above; only numeric values reach here.
 		estimateStr, _ := cmd.Flags().GetString("estimate")
 		e, err := parseEstimate(estimateStr)
 		if err != nil {

--- a/cmd/linear/commands/issue/update.go
+++ b/cmd/linear/commands/issue/update.go
@@ -2,6 +2,7 @@ package issue
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -19,7 +20,7 @@ func NewUpdateCommand(clientFactory cli.ClientFactory) *cobra.Command {
 		Short: "Update an existing issue",
 		Long: `Update issue. Modifies existing data.
 
-Fields: --title, --description, --assignee (name/email/ID/'me'/'none'), --state, --priority (0-4), --cycle, --project, --parent, --due-date (YYYY-MM-DD or 'none'), --milestone (uuid or 'none'), --add-label, --remove-label, --link-pr
+Fields: --title, --description, --assignee (name/email/ID/'me'/'none'), --state, --priority (0-4), --estimate (number or 'none' to clear), --cycle, --project, --parent, --due-date (YYYY-MM-DD or 'none'), --milestone (uuid or 'none'), --add-label, --remove-label, --link-pr
 
 Example: go-linear issue update ENG-123 --state=Done --due-date=2025-03-01
 
@@ -42,6 +43,7 @@ Related: issue_get, issue_create`,
 	cmd.Flags().String("assignee", "", "New assignee name, email, or ID (use 'none' to unassign)")
 	cmd.Flags().String("state", "", "New state name or ID")
 	cmd.Flags().Int("priority", -1, "New priority: 0=none, 1=urgent, 2=high, 3=normal, 4=low")
+	cmd.Flags().String("estimate", "", "Story points/estimate (use 'none' to clear)")
 	cmd.Flags().String("cycle", "", "Cycle name or UUID (use 'none' to remove)")
 	cmd.Flags().String("project", "", "Project name or UUID (use 'none' to remove)")
 	cmd.Flags().String("parent", "", "Parent issue ID/identifier (use 'none' to remove)")
@@ -94,6 +96,11 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 			needsNullable = true
 		}
 	}
+	if cmd.Flags().Changed("estimate") {
+		if estimate, _ := cmd.Flags().GetString("estimate"); estimate == "none" {
+			needsNullable = true
+		}
+	}
 
 	if needsNullable {
 		return runUpdateWithNullable(cmd, client, resolvedIssueID, res)
@@ -137,6 +144,16 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 		}
 		p := int64(priority)
 		input.Priority = &p
+		updated = true
+	}
+
+	if cmd.Flags().Changed("estimate") {
+		estimateStr, _ := cmd.Flags().GetString("estimate")
+		e, err := parseEstimate(estimateStr)
+		if err != nil {
+			return err
+		}
+		input.Estimate = &e
 		updated = true
 	}
 
@@ -281,6 +298,14 @@ func contains(s, substr string) bool {
 	return len(s) >= len(substr) && findSubstring(s, substr)
 }
 
+func parseEstimate(s string) (int64, error) {
+	e, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || e < 0 {
+		return 0, fmt.Errorf("invalid estimate %q: must be a non-negative integer or 'none'", s)
+	}
+	return e, nil
+}
+
 func findSubstring(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {
@@ -328,6 +353,19 @@ func runUpdateWithNullable(cmd *cobra.Command, client *linear.Client, issueID st
 	if priority, _ := cmd.Flags().GetInt("priority"); priority >= 0 {
 		p := int64(priority)
 		input.Priority = &p
+	}
+
+	if cmd.Flags().Changed("estimate") {
+		estimateStr, _ := cmd.Flags().GetString("estimate")
+		if estimateStr == "none" {
+			input.Estimate = linear.NewNull[int64]()
+		} else {
+			e, err := parseEstimate(estimateStr)
+			if err != nil {
+				return err
+			}
+			input.Estimate = linear.NewValue(e)
+		}
 	}
 
 	addLabels, _ := cmd.Flags().GetStringArray("add-label")

--- a/cmd/linear/commands/issue/update.go
+++ b/cmd/linear/commands/issue/update.go
@@ -97,9 +97,7 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 		}
 	}
 	if cmd.Flags().Changed("estimate") {
-		if estimate, _ := cmd.Flags().GetString("estimate"); estimate == "none" {
-			needsNullable = true
-		}
+		needsNullable = true
 	}
 
 	if needsNullable {
@@ -144,17 +142,6 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 		}
 		p := int64(priority)
 		input.Priority = &p
-		updated = true
-	}
-
-	if cmd.Flags().Changed("estimate") {
-		// "none" is handled by runUpdateWithNullable above; only numeric values reach here.
-		estimateStr, _ := cmd.Flags().GetString("estimate")
-		e, err := parseEstimate(estimateStr)
-		if err != nil {
-			return err
-		}
-		input.Estimate = &e
 		updated = true
 	}
 
@@ -299,10 +286,10 @@ func contains(s, substr string) bool {
 	return len(s) >= len(substr) && findSubstring(s, substr)
 }
 
-func parseEstimate(s string) (int64, error) {
-	e, err := strconv.ParseInt(s, 10, 64)
+func parseEstimate(s string) (float64, error) {
+	e, err := strconv.ParseFloat(s, 64)
 	if err != nil || e < 0 {
-		return 0, fmt.Errorf("invalid estimate %q: must be a non-negative integer or 'none'", s)
+		return 0, fmt.Errorf("invalid estimate %q: must be a non-negative number or 'none'", s)
 	}
 	return e, nil
 }
@@ -359,7 +346,7 @@ func runUpdateWithNullable(cmd *cobra.Command, client *linear.Client, issueID st
 	if cmd.Flags().Changed("estimate") {
 		estimateStr, _ := cmd.Flags().GetString("estimate")
 		if estimateStr == "none" {
-			input.Estimate = linear.NewNull[int64]()
+			input.Estimate = linear.NewNull[float64]()
 		} else {
 			e, err := parseEstimate(estimateStr)
 			if err != nil {

--- a/cmd/linear/commands/issue/update_test.go
+++ b/cmd/linear/commands/issue/update_test.go
@@ -3,9 +3,13 @@ package issue
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/chainguard-sandbox/go-linear/v2/internal/testutil"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
 )
 
 func TestNewUpdateCommand(t *testing.T) {
@@ -185,6 +189,23 @@ func TestRunUpdate(t *testing.T) {
 		}
 	})
 
+	t.Run("update estimate with float", func(t *testing.T) {
+		cmd := NewUpdateCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"ENG-123", "--estimate=1.5"})
+
+		err := cmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Errorf("Output should be valid JSON: %v", err)
+		}
+	})
+
 	t.Run("update cycle by name", func(t *testing.T) {
 		cmd := NewUpdateCommand(factory)
 		var buf bytes.Buffer
@@ -199,6 +220,94 @@ func TestRunUpdate(t *testing.T) {
 		var result map[string]any
 		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
 			t.Errorf("Output should be valid JSON: %v", err)
+		}
+	})
+}
+
+type updateCapture struct {
+	Input map[string]any
+}
+
+func captureUpdateServer(t *testing.T) (*httptest.Server, *updateCapture) {
+	t.Helper()
+	captured := &updateCapture{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		var reqBody struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if strings.EqualFold(reqBody.OperationName, "UpdateIssue") {
+			if input, ok := reqBody.Variables["input"].(map[string]any); ok {
+				captured.Input = input
+			}
+		}
+		handlers := defaultHandlers()
+		for key, resp := range handlers {
+			if strings.EqualFold(key, reqBody.OperationName) {
+				_, _ = w.Write([]byte(resp))
+				return
+			}
+		}
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	return server, captured
+}
+
+func TestRunUpdate_EstimatePayload(t *testing.T) {
+	t.Run("estimate value sent in mutation", func(t *testing.T) {
+		server, captured := captureUpdateServer(t)
+		defer server.Close()
+		factory := func() (*linear.Client, error) {
+			return linear.NewClient("test_api_key", linear.WithBaseURL(server.URL))
+		}
+
+		cmd := NewUpdateCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"ENG-123", "--estimate=5"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		if captured.Input == nil {
+			t.Fatal("no UpdateIssue mutation captured")
+		}
+		if captured.Input["estimate"] != float64(5) {
+			t.Errorf("estimate = %v (%T), want float64(5)", captured.Input["estimate"], captured.Input["estimate"])
+		}
+	})
+
+	t.Run("estimate null sent in mutation when none", func(t *testing.T) {
+		server, captured := captureUpdateServer(t)
+		defer server.Close()
+		factory := func() (*linear.Client, error) {
+			return linear.NewClient("test_api_key", linear.WithBaseURL(server.URL))
+		}
+
+		cmd := NewUpdateCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"ENG-123", "--estimate=none"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		if captured.Input == nil {
+			t.Fatal("no UpdateIssue mutation captured")
+		}
+		estimateVal, exists := captured.Input["estimate"]
+		if !exists {
+			t.Error("estimate key missing from mutation input")
+		}
+		if estimateVal != nil {
+			t.Errorf("estimate = %v, want nil (explicit null)", estimateVal)
 		}
 	})
 }

--- a/cmd/linear/commands/issue/update_test.go
+++ b/cmd/linear/commands/issue/update_test.go
@@ -24,7 +24,7 @@ func TestNewUpdateCommand(t *testing.T) {
 	t.Run("flags exist", func(t *testing.T) {
 		expectedFlags := []string{
 			"title", "description", "assignee", "state",
-			"priority", "cycle", "project", "parent",
+			"priority", "estimate", "cycle", "project", "parent",
 			"add-label", "remove-label",
 			"due-date", "milestone",
 		}
@@ -139,6 +139,40 @@ func TestRunUpdate(t *testing.T) {
 		var buf bytes.Buffer
 		cmd.SetOut(&buf)
 		cmd.SetArgs([]string{"ENG-123", "--project=Test Project"})
+
+		err := cmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Errorf("Output should be valid JSON: %v", err)
+		}
+	})
+
+	t.Run("update estimate", func(t *testing.T) {
+		cmd := NewUpdateCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"ENG-123", "--estimate=5"})
+
+		err := cmd.Execute()
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Errorf("Output should be valid JSON: %v", err)
+		}
+	})
+
+	t.Run("clear estimate with none", func(t *testing.T) {
+		cmd := NewUpdateCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"ENG-123", "--estimate=none"})
 
 		err := cmd.Execute()
 		if err != nil {

--- a/pkg/linear/issue_update_nullable.go
+++ b/pkg/linear/issue_update_nullable.go
@@ -126,7 +126,7 @@ type IssueUpdateNullableInput struct {
 	Description     *string
 	StateID         *string
 	Priority        *int64
-	Estimate        Nullable[int64]
+	Estimate        Nullable[float64]
 	AddedLabelIds   []string
 	RemovedLabelIds []string
 
@@ -165,12 +165,11 @@ func (i *IssueUpdateNullableInput) ToMap() map[string]any {
 		m["priority"] = *i.Priority
 	}
 	if i.Estimate.IsSet() {
-		if val, ok := i.Estimate.Get(); ok {
-			if val == nil {
-				m["estimate"] = nil
-			} else {
-				m["estimate"] = *val
-			}
+		val, _ := i.Estimate.Get()
+		if val == nil {
+			m["estimate"] = nil
+		} else {
+			m["estimate"] = *val
 		}
 	}
 	if len(i.AddedLabelIds) > 0 {

--- a/pkg/linear/issue_update_nullable.go
+++ b/pkg/linear/issue_update_nullable.go
@@ -126,6 +126,7 @@ type IssueUpdateNullableInput struct {
 	Description     *string
 	StateID         *string
 	Priority        *int64
+	Estimate        Nullable[int64]
 	AddedLabelIds   []string
 	RemovedLabelIds []string
 
@@ -162,6 +163,15 @@ func (i *IssueUpdateNullableInput) ToMap() map[string]any {
 	}
 	if i.Priority != nil {
 		m["priority"] = *i.Priority
+	}
+	if i.Estimate.IsSet() {
+		if val, ok := i.Estimate.Get(); ok {
+			if val == nil {
+				m["estimate"] = nil
+			} else {
+				m["estimate"] = *val
+			}
+		}
 	}
 	if len(i.AddedLabelIds) > 0 {
 		m["addedLabelIds"] = i.AddedLabelIds

--- a/pkg/linear/nullable_test.go
+++ b/pkg/linear/nullable_test.go
@@ -286,18 +286,29 @@ func TestIssueUpdateNullableInput_ToMap(t *testing.T) {
 	// With value estimate
 	t.Run("with value estimate", func(t *testing.T) {
 		input := IssueUpdateNullableInput{
-			Estimate: NewValue(int64(5)),
+			Estimate: NewValue(float64(5)),
 		}
 		m := input.ToMap()
-		if m["estimate"] != int64(5) {
+		if m["estimate"] != float64(5) {
 			t.Errorf("Expected estimate=5, got %v", m["estimate"])
+		}
+	})
+
+	// With float estimate
+	t.Run("with float estimate", func(t *testing.T) {
+		input := IssueUpdateNullableInput{
+			Estimate: NewValue(1.5),
+		}
+		m := input.ToMap()
+		if m["estimate"] != 1.5 {
+			t.Errorf("Expected estimate=1.5, got %v", m["estimate"])
 		}
 	})
 
 	// With null estimate (explicit clear)
 	t.Run("with null estimate", func(t *testing.T) {
 		input := IssueUpdateNullableInput{
-			Estimate: NewNull[int64](),
+			Estimate: NewNull[float64](),
 		}
 		m := input.ToMap()
 		if _, exists := m["estimate"]; !exists {
@@ -311,7 +322,7 @@ func TestIssueUpdateNullableInput_ToMap(t *testing.T) {
 	// With unset estimate (should not appear in map)
 	t.Run("with unset estimate", func(t *testing.T) {
 		input := IssueUpdateNullableInput{
-			Estimate: NewUnset[int64](),
+			Estimate: NewUnset[float64](),
 		}
 		m := input.ToMap()
 		if _, exists := m["estimate"]; exists {
@@ -325,7 +336,7 @@ func TestIssueUpdateNullableInput_ToMap(t *testing.T) {
 		desc := "Desc"
 		state := "state-id"
 		priority := int64(1)
-		estimate := int64(3)
+		estimate := float64(3)
 		input := IssueUpdateNullableInput{
 			Title:           &title,
 			Description:     &desc,
@@ -357,7 +368,7 @@ func TestIssueUpdateNullableInput_ToMap(t *testing.T) {
 			t.Errorf("Expected priority=%d", priority)
 		}
 		if m["estimate"] != estimate {
-			t.Errorf("Expected estimate=%d, got %v", estimate, m["estimate"])
+			t.Errorf("Expected estimate=%v, got %v", estimate, m["estimate"])
 		}
 		if m["cycleId"] != "cycle-id" {
 			t.Errorf("Expected cycleId=cycle-id")

--- a/pkg/linear/nullable_test.go
+++ b/pkg/linear/nullable_test.go
@@ -283,18 +283,56 @@ func TestIssueUpdateNullableInput_ToMap(t *testing.T) {
 		}
 	})
 
+	// With value estimate
+	t.Run("with value estimate", func(t *testing.T) {
+		input := IssueUpdateNullableInput{
+			Estimate: NewValue(int64(5)),
+		}
+		m := input.ToMap()
+		if m["estimate"] != int64(5) {
+			t.Errorf("Expected estimate=5, got %v", m["estimate"])
+		}
+	})
+
+	// With null estimate (explicit clear)
+	t.Run("with null estimate", func(t *testing.T) {
+		input := IssueUpdateNullableInput{
+			Estimate: NewNull[int64](),
+		}
+		m := input.ToMap()
+		if _, exists := m["estimate"]; !exists {
+			t.Error("Expected estimate to be in map")
+		}
+		if m["estimate"] != nil {
+			t.Errorf("Expected estimate=nil, got %v", m["estimate"])
+		}
+	})
+
+	// With unset estimate (should not appear in map)
+	t.Run("with unset estimate", func(t *testing.T) {
+		input := IssueUpdateNullableInput{
+			Estimate: NewUnset[int64](),
+		}
+		m := input.ToMap()
+		if _, exists := m["estimate"]; exists {
+			t.Error("Expected estimate to NOT be in map for unset")
+		}
+	})
+
 	// All fields
 	t.Run("all fields", func(t *testing.T) {
 		title := "Title"
 		desc := "Desc"
 		state := "state-id"
 		priority := int64(1)
+		estimate := int64(3)
 		input := IssueUpdateNullableInput{
 			Title:           &title,
 			Description:     &desc,
 			AssigneeID:      NewValue("assignee-id"),
 			StateID:         &state,
 			Priority:        &priority,
+			Estimate:        NewValue(estimate),
 			AddedLabelIds:   []string{"label-1"},
 			RemovedLabelIds: []string{"label-2"},
 			CycleID:         NewValue("cycle-id"),
@@ -317,6 +355,9 @@ func TestIssueUpdateNullableInput_ToMap(t *testing.T) {
 		}
 		if m["priority"] != priority {
 			t.Errorf("Expected priority=%d", priority)
+		}
+		if m["estimate"] != estimate {
+			t.Errorf("Expected estimate=%d, got %v", estimate, m["estimate"])
 		}
 		if m["cycleId"] != "cycle-id" {
 			t.Errorf("Expected cycleId=cycle-id")


### PR DESCRIPTION
## What

Adds \`--estimate\` support to \`issue update\`, accepting a non-negative number (including floats like \`1.5\`) or \`none\` to clear the estimate. The flag was previously only available on \`issue create\` and \`issue batch-update\`.

## Why

There was no way to update an estimate on a single issue via the CLI. Users had to fall back to the Linear UI or use batch-update even for one issue.

## Notes

- \`--estimate\` uses a String flag (not Int) to support the \`none\` sentinel, consistent with \`--parent\`, \`--cycle\`, \`--due-date\`, etc.
- All estimate changes route through \`runUpdateWithNullable\` — \`none\` sends explicit null, numeric values send \`float64\` matching the Linear GraphQL \`Float\` type. Teams with fractional estimate scales (e.g. 0.5, 1.5) are supported.
- \`IssueUpdateNullableInput.Estimate\` is \`Nullable[float64]\`; \`ToMap()\` handles value, null, and unset states. Redundant \`ok\`-after-\`IsSet()\` check removed.
- \`parseEstimate()\` rejects negative values and non-numeric strings with a clear error message.

## Testing

- Unit tests for \`--estimate=5\` (integer), \`--estimate=1.5\` (float), and \`--estimate=none\` (clear) in \`TestRunUpdate\`
- Wire payload tests in \`TestRunUpdate_EstimatePayload\` assert \`estimate: 5\` and \`estimate: null\` actually appear in the GraphQL mutation request body
- \`ToMap()\` coverage for value, null, unset, and float estimate cases in \`TestIssueUpdateNullableInput_ToMap\`
- \`make check\` passes (fmt, vet, lint, tests, tidy)