### PR TITLE
feat(issue): add --estimate flag to issue update

### DIFF
--- a/cmd/linear/commands/notification/archive_all.go
+++ b/cmd/linear/commands/notification/archive_all.go
@@ -1,14 +1,12 @@
 package notification
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
 	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
-	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
 	"github.com/chainguard-sandbox/go-linear/v2/internal/resolver"
 	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
 )
@@ -59,55 +57,3 @@ func runArchiveAll(cmd *cobra.Command, client *linear.Client) error {
 	}, true)
 }
 
-// addEntityFlags adds the common entity filter flags for bulk notification operations.
-func addEntityFlags(cmd *cobra.Command) {
-	cmd.Flags().String("issue", "", "Issue identifier or UUID (e.g., ENG-123)")
-	cmd.Flags().String("project", "", "Project name or UUID")
-	cmd.Flags().String("initiative", "", "Initiative name or UUID")
-	cmd.Flags().String("notification", "", "Notification ID (UUID)")
-}
-
-// buildEntityInput constructs a NotificationEntityInput from flags, resolving
-// human-readable identifiers (issue keys, project/initiative names) to UUIDs.
-func buildEntityInput(cmd *cobra.Command, ctx context.Context, res *resolver.Resolver) (intgraphql.NotificationEntityInput, error) {
-	input := intgraphql.NotificationEntityInput{}
-	set := 0
-
-	if v, _ := cmd.Flags().GetString("issue"); v != "" {
-		id, err := res.ResolveIssue(ctx, v)
-		if err != nil {
-			return input, fmt.Errorf("failed to resolve issue: %w", err)
-		}
-		input.IssueID = &id
-		set++
-	}
-	if v, _ := cmd.Flags().GetString("project"); v != "" {
-		id, err := res.ResolveProject(ctx, v)
-		if err != nil {
-			return input, fmt.Errorf("failed to resolve project: %w", err)
-		}
-		input.ProjectID = &id
-		set++
-	}
-	if v, _ := cmd.Flags().GetString("initiative"); v != "" {
-		id, err := res.ResolveInitiative(ctx, v)
-		if err != nil {
-			return input, fmt.Errorf("failed to resolve initiative: %w", err)
-		}
-		input.InitiativeID = &id
-		set++
-	}
-	if v, _ := cmd.Flags().GetString("notification"); v != "" {
-		input.ID = &v
-		set++
-	}
-
-	if set == 0 {
-		return input, fmt.Errorf("one of --issue, --project, --initiative, or --notification is required")
-	}
-	if set > 1 {
-		return input, fmt.Errorf("only one of --issue, --project, --initiative, or --notification may be specified")
-	}
-
-	return input, nil
-}

--- a/cmd/linear/commands/notification/archive_all.go
+++ b/cmd/linear/commands/notification/archive_all.go
@@ -1,6 +1,7 @@
 package notification
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -8,6 +9,7 @@ import (
 	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
 	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
 	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/resolver"
 	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
 )
 
@@ -40,8 +42,9 @@ Related: notification_archive, notification_mark-read-all`,
 
 func runArchiveAll(cmd *cobra.Command, client *linear.Client) error {
 	ctx := cmd.Context()
+	res := resolver.New(client)
 
-	input, err := buildEntityInput(cmd)
+	input, err := buildEntityInput(cmd, ctx, res)
 	if err != nil {
 		return err
 	}
@@ -58,27 +61,40 @@ func runArchiveAll(cmd *cobra.Command, client *linear.Client) error {
 
 // addEntityFlags adds the common entity filter flags for bulk notification operations.
 func addEntityFlags(cmd *cobra.Command) {
-	cmd.Flags().String("issue", "", "Issue ID (e.g., ENG-123 or UUID)")
-	cmd.Flags().String("project", "", "Project ID (UUID)")
-	cmd.Flags().String("initiative", "", "Initiative ID (UUID)")
+	cmd.Flags().String("issue", "", "Issue identifier or UUID (e.g., ENG-123)")
+	cmd.Flags().String("project", "", "Project name or UUID")
+	cmd.Flags().String("initiative", "", "Initiative name or UUID")
 	cmd.Flags().String("notification", "", "Notification ID (UUID)")
 }
 
-// buildEntityInput constructs a NotificationEntityInput from flags.
-func buildEntityInput(cmd *cobra.Command) (intgraphql.NotificationEntityInput, error) {
+// buildEntityInput constructs a NotificationEntityInput from flags, resolving
+// human-readable identifiers (issue keys, project/initiative names) to UUIDs.
+func buildEntityInput(cmd *cobra.Command, ctx context.Context, res *resolver.Resolver) (intgraphql.NotificationEntityInput, error) {
 	input := intgraphql.NotificationEntityInput{}
 	set := 0
 
 	if v, _ := cmd.Flags().GetString("issue"); v != "" {
-		input.IssueID = &v
+		id, err := res.ResolveIssue(ctx, v)
+		if err != nil {
+			return input, fmt.Errorf("failed to resolve issue: %w", err)
+		}
+		input.IssueID = &id
 		set++
 	}
 	if v, _ := cmd.Flags().GetString("project"); v != "" {
-		input.ProjectID = &v
+		id, err := res.ResolveProject(ctx, v)
+		if err != nil {
+			return input, fmt.Errorf("failed to resolve project: %w", err)
+		}
+		input.ProjectID = &id
 		set++
 	}
 	if v, _ := cmd.Flags().GetString("initiative"); v != "" {
-		input.InitiativeID = &v
+		id, err := res.ResolveInitiative(ctx, v)
+		if err != nil {
+			return input, fmt.Errorf("failed to resolve initiative: %w", err)
+		}
+		input.InitiativeID = &id
 		set++
 	}
 	if v, _ := cmd.Flags().GetString("notification"); v != "" {

--- a/cmd/linear/commands/notification/archive_all.go
+++ b/cmd/linear/commands/notification/archive_all.go
@@ -1,0 +1,97 @@
+package notification
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewArchiveAllCommand creates the notification archive-all command.
+func NewArchiveAllCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "archive-all",
+		Short: "Archive all notifications for an entity",
+		Long: `Archive all notifications related to a specific entity (issue, project, initiative).
+
+Requires exactly one of: --issue, --project, --initiative, --notification
+
+Example: go-linear notification archive-all --issue=ENG-123
+
+Related: notification_archive, notification_mark-read-all`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runArchiveAll(cmd, client)
+		},
+	}
+
+	addEntityFlags(cmd)
+	return cmd
+}
+
+func runArchiveAll(cmd *cobra.Command, client *linear.Client) error {
+	ctx := cmd.Context()
+
+	input, err := buildEntityInput(cmd)
+	if err != nil {
+		return err
+	}
+
+	if err := client.NotificationArchiveAll(ctx, input); err != nil {
+		return fmt.Errorf("failed to archive all notifications: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), map[string]any{
+		"success": true,
+		"action":  "archive-all",
+	}, true)
+}
+
+// addEntityFlags adds the common entity filter flags for bulk notification operations.
+func addEntityFlags(cmd *cobra.Command) {
+	cmd.Flags().String("issue", "", "Issue ID (e.g., ENG-123 or UUID)")
+	cmd.Flags().String("project", "", "Project ID (UUID)")
+	cmd.Flags().String("initiative", "", "Initiative ID (UUID)")
+	cmd.Flags().String("notification", "", "Notification ID (UUID)")
+}
+
+// buildEntityInput constructs a NotificationEntityInput from flags.
+func buildEntityInput(cmd *cobra.Command) (intgraphql.NotificationEntityInput, error) {
+	input := intgraphql.NotificationEntityInput{}
+	set := 0
+
+	if v, _ := cmd.Flags().GetString("issue"); v != "" {
+		input.IssueID = &v
+		set++
+	}
+	if v, _ := cmd.Flags().GetString("project"); v != "" {
+		input.ProjectID = &v
+		set++
+	}
+	if v, _ := cmd.Flags().GetString("initiative"); v != "" {
+		input.InitiativeID = &v
+		set++
+	}
+	if v, _ := cmd.Flags().GetString("notification"); v != "" {
+		input.ID = &v
+		set++
+	}
+
+	if set == 0 {
+		return input, fmt.Errorf("one of --issue, --project, --initiative, or --notification is required")
+	}
+	if set > 1 {
+		return input, fmt.Errorf("only one of --issue, --project, --initiative, or --notification may be specified")
+	}
+
+	return input, nil
+}

--- a/cmd/linear/commands/notification/bulk_test.go
+++ b/cmd/linear/commands/notification/bulk_test.go
@@ -1,0 +1,129 @@
+package notification
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/testutil"
+)
+
+func TestNewArchiveAllCommand(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewArchiveAllCommand(factory)
+	if cmd.Use != "archive-all" {
+		t.Errorf("Use = %q, want %q", cmd.Use, "archive-all")
+	}
+}
+
+func TestRunArchiveAll(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	t.Run("archive all for issue", func(t *testing.T) {
+		cmd := NewArchiveAllCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"--issue=00000000-0000-0000-0000-000000000001"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("Output should be valid JSON: %v", err)
+		}
+		if result["success"] != true {
+			t.Error("Expected success: true")
+		}
+	})
+
+	t.Run("requires entity flag", func(t *testing.T) {
+		cmd := NewArchiveAllCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		cmd.SetArgs([]string{})
+		if err := cmd.Execute(); err == nil {
+			t.Error("Expected error when no entity flag provided")
+		}
+	})
+}
+
+func TestRunMarkReadAll(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewMarkReadAllCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--issue=00000000-0000-0000-0000-000000000001"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestRunMarkUnreadAll(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewMarkUnreadAllCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--issue=00000000-0000-0000-0000-000000000001"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestRunSnoozeAll(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	t.Run("snooze with future duration", func(t *testing.T) {
+		cmd := NewSnoozeAllCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"--issue=00000000-0000-0000-0000-000000000001", "--until=3d"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("Output should be valid JSON: %v", err)
+		}
+		if result["success"] != true {
+			t.Error("Expected success: true")
+		}
+	})
+
+	t.Run("snooze with tomorrow", func(t *testing.T) {
+		cmd := NewSnoozeAllCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"--issue=00000000-0000-0000-0000-000000000001", "--until=tomorrow"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	})
+}
+
+func TestRunUnsnoozeAll(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewUnsnoozeAllCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--issue=00000000-0000-0000-0000-000000000001"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}

--- a/cmd/linear/commands/notification/bulk_test.go
+++ b/cmd/linear/commands/notification/bulk_test.go
@@ -51,6 +51,20 @@ func TestRunArchiveAll(t *testing.T) {
 			t.Error("Expected error when no entity flag provided")
 		}
 	})
+
+	t.Run("rejects multiple entity flags", func(t *testing.T) {
+		cmd := NewArchiveAllCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		cmd.SetArgs([]string{
+			"--issue=00000000-0000-0000-0000-000000000001",
+			"--project=00000000-0000-0000-0000-000000000002",
+		})
+		if err := cmd.Execute(); err == nil {
+			t.Error("Expected error when multiple entity flags provided")
+		}
+	})
 }
 
 func TestRunMarkReadAll(t *testing.T) {

--- a/cmd/linear/commands/notification/entity_flags.go
+++ b/cmd/linear/commands/notification/entity_flags.go
@@ -1,0 +1,64 @@
+package notification
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/resolver"
+)
+
+// addEntityFlags adds the common entity filter flags for bulk notification operations.
+func addEntityFlags(cmd *cobra.Command) {
+	cmd.Flags().String("issue", "", "Issue identifier or UUID (e.g., ENG-123)")
+	cmd.Flags().String("project", "", "Project name or UUID")
+	cmd.Flags().String("initiative", "", "Initiative name or UUID")
+	cmd.Flags().String("notification", "", "Notification ID (UUID)")
+}
+
+// buildEntityInput constructs a NotificationEntityInput from flags, resolving
+// human-readable identifiers (issue keys, project/initiative names) to UUIDs.
+func buildEntityInput(cmd *cobra.Command, ctx context.Context, res *resolver.Resolver) (intgraphql.NotificationEntityInput, error) {
+	input := intgraphql.NotificationEntityInput{}
+	set := 0
+
+	if v, _ := cmd.Flags().GetString("issue"); v != "" {
+		id, err := res.ResolveIssue(ctx, v)
+		if err != nil {
+			return input, fmt.Errorf("failed to resolve issue: %w", err)
+		}
+		input.IssueID = &id
+		set++
+	}
+	if v, _ := cmd.Flags().GetString("project"); v != "" {
+		id, err := res.ResolveProject(ctx, v)
+		if err != nil {
+			return input, fmt.Errorf("failed to resolve project: %w", err)
+		}
+		input.ProjectID = &id
+		set++
+	}
+	if v, _ := cmd.Flags().GetString("initiative"); v != "" {
+		id, err := res.ResolveInitiative(ctx, v)
+		if err != nil {
+			return input, fmt.Errorf("failed to resolve initiative: %w", err)
+		}
+		input.InitiativeID = &id
+		set++
+	}
+	if v, _ := cmd.Flags().GetString("notification"); v != "" {
+		input.ID = &v
+		set++
+	}
+
+	if set == 0 {
+		return input, fmt.Errorf("one of --issue, --project, --initiative, or --notification is required")
+	}
+	if set > 1 {
+		return input, fmt.Errorf("only one of --issue, --project, --initiative, or --notification may be specified")
+	}
+
+	return input, nil
+}

--- a/cmd/linear/commands/notification/helpers_test.go
+++ b/cmd/linear/commands/notification/helpers_test.go
@@ -6,6 +6,12 @@ const (
 	mockSubscribeResponse           = `{"data": {"notificationSubscriptionCreate": {"success": true, "notificationSubscription": {"id": "sub-123"}}}}`
 	mockUnsubscribeResponse         = `{"data": {"notificationSubscriptionDelete": {"success": true}}}`
 	mockProjectsResponse            = `{"data": {"projects": {"nodes": [{"id": "proj-123", "name": "Test Project"}], "pageInfo": {"hasNextPage": false}}}}`
+	mockNotificationArchiveAllResponse   = `{"data": {"notificationArchiveAll": {"success": true}}}`
+	mockNotificationMarkReadAllResponse  = `{"data": {"notificationMarkReadAll": {"success": true}}}`
+	mockNotificationMarkUnreadAllResponse = `{"data": {"notificationMarkUnreadAll": {"success": true}}}`
+	mockNotificationSnoozeAllResponse    = `{"data": {"notificationSnoozeAll": {"success": true}}}`
+	mockNotificationUnsnoozeAllResponse  = `{"data": {"notificationUnsnoozeAll": {"success": true}}}`
+	mockIssuesResponse                   = `{"data": {"issues": {"nodes": [{"id": "issue-123", "identifier": "ENG-123", "title": "Test"}], "pageInfo": {"hasNextPage": false}}}}`
 )
 
 func defaultHandlers() map[string]string {
@@ -15,5 +21,12 @@ func defaultHandlers() map[string]string {
 		"NotificationSubscriptionCreate": mockSubscribeResponse,
 		"NotificationSubscriptionDelete": mockUnsubscribeResponse,
 		"ListProjects":                   mockProjectsResponse,
+		"NotificationArchiveAll":         mockNotificationArchiveAllResponse,
+		"NotificationMarkReadAll":        mockNotificationMarkReadAllResponse,
+		"NotificationMarkUnreadAll":      mockNotificationMarkUnreadAllResponse,
+		"NotificationSnoozeAll":          mockNotificationSnoozeAllResponse,
+		"NotificationUnsnoozeAll":        mockNotificationUnsnoozeAllResponse,
+		"SearchIssues":                   mockIssuesResponse,
+		"ListIssues":                     mockIssuesResponse,
 	}
 }

--- a/cmd/linear/commands/notification/helpers_test.go
+++ b/cmd/linear/commands/notification/helpers_test.go
@@ -1,17 +1,17 @@
 package notification
 
 const (
-	mockNotificationArchiveResponse = `{"data": {"notificationArchive": {"success": true}}}`
-	mockNotificationUpdateResponse  = `{"data": {"notificationUpdate": {"success": true, "notification": {"id": "notif-123", "readAt": "2024-01-01T00:00:00.000Z"}}}}`
-	mockSubscribeResponse           = `{"data": {"notificationSubscriptionCreate": {"success": true, "notificationSubscription": {"id": "sub-123"}}}}`
-	mockUnsubscribeResponse         = `{"data": {"notificationSubscriptionDelete": {"success": true}}}`
-	mockProjectsResponse            = `{"data": {"projects": {"nodes": [{"id": "proj-123", "name": "Test Project"}], "pageInfo": {"hasNextPage": false}}}}`
-	mockNotificationArchiveAllResponse   = `{"data": {"notificationArchiveAll": {"success": true}}}`
-	mockNotificationMarkReadAllResponse  = `{"data": {"notificationMarkReadAll": {"success": true}}}`
+	mockNotificationArchiveResponse       = `{"data": {"notificationArchive": {"success": true}}}`
+	mockNotificationUpdateResponse        = `{"data": {"notificationUpdate": {"success": true, "notification": {"id": "notif-123", "readAt": "2024-01-01T00:00:00.000Z"}}}}`
+	mockSubscribeResponse                 = `{"data": {"notificationSubscriptionCreate": {"success": true, "notificationSubscription": {"id": "sub-123"}}}}`
+	mockUnsubscribeResponse               = `{"data": {"notificationSubscriptionDelete": {"success": true}}}`
+	mockProjectsResponse                  = `{"data": {"projects": {"nodes": [{"id": "proj-123", "name": "Test Project"}], "pageInfo": {"hasNextPage": false}}}}`
+	mockNotificationArchiveAllResponse    = `{"data": {"notificationArchiveAll": {"success": true}}}`
+	mockNotificationMarkReadAllResponse   = `{"data": {"notificationMarkReadAll": {"success": true}}}`
 	mockNotificationMarkUnreadAllResponse = `{"data": {"notificationMarkUnreadAll": {"success": true}}}`
-	mockNotificationSnoozeAllResponse    = `{"data": {"notificationSnoozeAll": {"success": true}}}`
-	mockNotificationUnsnoozeAllResponse  = `{"data": {"notificationUnsnoozeAll": {"success": true}}}`
-	mockIssuesResponse                   = `{"data": {"issues": {"nodes": [{"id": "issue-123", "identifier": "ENG-123", "title": "Test"}], "pageInfo": {"hasNextPage": false}}}}`
+	mockNotificationSnoozeAllResponse     = `{"data": {"notificationSnoozeAll": {"success": true}}}`
+	mockNotificationUnsnoozeAllResponse   = `{"data": {"notificationUnsnoozeAll": {"success": true}}}`
+	mockIssuesResponse                    = `{"data": {"issues": {"nodes": [{"id": "issue-123", "identifier": "ENG-123", "title": "Test"}], "pageInfo": {"hasNextPage": false}}}}`
 )
 
 func defaultHandlers() map[string]string {

--- a/cmd/linear/commands/notification/mark_read_all.go
+++ b/cmd/linear/commands/notification/mark_read_all.go
@@ -1,0 +1,57 @@
+package notification
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewMarkReadAllCommand creates the notification mark-read-all command.
+func NewMarkReadAllCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mark-read-all",
+		Short: "Mark all notifications as read for an entity",
+		Long: `Mark all notifications as read for a specific entity (issue, project, initiative).
+
+Requires exactly one of: --issue, --project, --initiative, --notification
+
+Example: go-linear notification mark-read-all --issue=ENG-123
+
+Related: notification_mark-unread-all, notification_archive-all`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runMarkReadAll(cmd, client)
+		},
+	}
+
+	addEntityFlags(cmd)
+	return cmd
+}
+
+func runMarkReadAll(cmd *cobra.Command, client *linear.Client) error {
+	ctx := cmd.Context()
+
+	input, err := buildEntityInput(cmd)
+	if err != nil {
+		return err
+	}
+
+	if err := client.NotificationMarkReadAll(ctx, input, time.Now()); err != nil {
+		return fmt.Errorf("failed to mark all notifications as read: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), map[string]any{
+		"success": true,
+		"action":  "mark-read-all",
+	}, true)
+}

--- a/cmd/linear/commands/notification/mark_read_all.go
+++ b/cmd/linear/commands/notification/mark_read_all.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
 	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/resolver"
 	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
 )
 
@@ -40,8 +41,9 @@ Related: notification_mark-unread-all, notification_archive-all`,
 
 func runMarkReadAll(cmd *cobra.Command, client *linear.Client) error {
 	ctx := cmd.Context()
+	res := resolver.New(client)
 
-	input, err := buildEntityInput(cmd)
+	input, err := buildEntityInput(cmd, ctx, res)
 	if err != nil {
 		return err
 	}

--- a/cmd/linear/commands/notification/mark_unread_all.go
+++ b/cmd/linear/commands/notification/mark_unread_all.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
 	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/resolver"
 	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
 )
 
@@ -39,8 +40,9 @@ Related: notification_mark-read-all, notification_archive-all`,
 
 func runMarkUnreadAll(cmd *cobra.Command, client *linear.Client) error {
 	ctx := cmd.Context()
+	res := resolver.New(client)
 
-	input, err := buildEntityInput(cmd)
+	input, err := buildEntityInput(cmd, ctx, res)
 	if err != nil {
 		return err
 	}

--- a/cmd/linear/commands/notification/mark_unread_all.go
+++ b/cmd/linear/commands/notification/mark_unread_all.go
@@ -1,0 +1,56 @@
+package notification
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewMarkUnreadAllCommand creates the notification mark-unread-all command.
+func NewMarkUnreadAllCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mark-unread-all",
+		Short: "Mark all notifications as unread for an entity",
+		Long: `Mark all notifications as unread for a specific entity (issue, project, initiative).
+
+Requires exactly one of: --issue, --project, --initiative, --notification
+
+Example: go-linear notification mark-unread-all --issue=ENG-123
+
+Related: notification_mark-read-all, notification_archive-all`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runMarkUnreadAll(cmd, client)
+		},
+	}
+
+	addEntityFlags(cmd)
+	return cmd
+}
+
+func runMarkUnreadAll(cmd *cobra.Command, client *linear.Client) error {
+	ctx := cmd.Context()
+
+	input, err := buildEntityInput(cmd)
+	if err != nil {
+		return err
+	}
+
+	if err := client.NotificationMarkUnreadAll(ctx, input); err != nil {
+		return fmt.Errorf("failed to mark all notifications as unread: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), map[string]any{
+		"success": true,
+		"action":  "mark-unread-all",
+	}, true)
+}

--- a/cmd/linear/commands/notification/notification.go
+++ b/cmd/linear/commands/notification/notification.go
@@ -25,6 +25,11 @@ func NewNotificationCommand(clientFactory cli.ClientFactory) *cobra.Command {
 	cmd.AddCommand(NewUnarchiveCommand(clientFactory))
 	cmd.AddCommand(NewSubscribeCommand(clientFactory))
 	cmd.AddCommand(NewUnsubscribeCommand(clientFactory))
+	cmd.AddCommand(NewArchiveAllCommand(clientFactory))
+	cmd.AddCommand(NewMarkReadAllCommand(clientFactory))
+	cmd.AddCommand(NewMarkUnreadAllCommand(clientFactory))
+	cmd.AddCommand(NewSnoozeAllCommand(clientFactory))
+	cmd.AddCommand(NewUnsnoozeAllCommand(clientFactory))
 
 	return cmd
 }

--- a/cmd/linear/commands/notification/snooze_all.go
+++ b/cmd/linear/commands/notification/snooze_all.go
@@ -53,7 +53,7 @@ func runSnoozeAll(cmd *cobra.Command, client *linear.Client) error {
 
 	untilStr, _ := cmd.Flags().GetString("until")
 	parser := dateparser.New()
-	until, err := parser.Parse(untilStr)
+	until, err := parser.ParseFuture(untilStr)
 	if err != nil {
 		return fmt.Errorf("invalid --until value: %w", err)
 	}

--- a/cmd/linear/commands/notification/snooze_all.go
+++ b/cmd/linear/commands/notification/snooze_all.go
@@ -9,6 +9,7 @@ import (
 	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
 	"github.com/chainguard-sandbox/go-linear/v2/internal/dateparser"
 	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/resolver"
 	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
 )
 
@@ -38,15 +39,16 @@ Related: notification_unsnooze-all, notification_archive-all`,
 	}
 
 	addEntityFlags(cmd)
-	cmd.Flags().String("until", "", "Snooze until (ISO8601, 'tomorrow', '3d', '1h')")
+	cmd.Flags().String("until", "", "Snooze until (ISO8601, 'tomorrow', '3d', '2w')")
 	_ = cmd.MarkFlagRequired("until")
 	return cmd
 }
 
 func runSnoozeAll(cmd *cobra.Command, client *linear.Client) error {
 	ctx := cmd.Context()
+	res := resolver.New(client)
 
-	input, err := buildEntityInput(cmd)
+	input, err := buildEntityInput(cmd, ctx, res)
 	if err != nil {
 		return err
 	}

--- a/cmd/linear/commands/notification/snooze_all.go
+++ b/cmd/linear/commands/notification/snooze_all.go
@@ -1,0 +1,74 @@
+package notification
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/dateparser"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewSnoozeAllCommand creates the notification snooze-all command.
+func NewSnoozeAllCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "snooze-all",
+		Short: "Snooze all notifications for an entity",
+		Long: `Snooze all notifications for a specific entity until a given time.
+
+Requires exactly one of: --issue, --project, --initiative, --notification
+Requires --until to specify when notifications should reappear.
+
+Example: go-linear notification snooze-all --issue=ENG-123 --until=tomorrow
+Example: go-linear notification snooze-all --issue=ENG-123 --until=3d
+
+Related: notification_unsnooze-all, notification_archive-all`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runSnoozeAll(cmd, client)
+		},
+	}
+
+	addEntityFlags(cmd)
+	cmd.Flags().String("until", "", "Snooze until (ISO8601, 'tomorrow', '3d', '1h')")
+	_ = cmd.MarkFlagRequired("until")
+	return cmd
+}
+
+func runSnoozeAll(cmd *cobra.Command, client *linear.Client) error {
+	ctx := cmd.Context()
+
+	input, err := buildEntityInput(cmd)
+	if err != nil {
+		return err
+	}
+
+	untilStr, _ := cmd.Flags().GetString("until")
+	parser := dateparser.New()
+	until, err := parser.Parse(untilStr)
+	if err != nil {
+		return fmt.Errorf("invalid --until value: %w", err)
+	}
+
+	if until.Before(time.Now()) {
+		return fmt.Errorf("--until must be in the future")
+	}
+
+	if err := client.NotificationSnoozeAll(ctx, input, until); err != nil {
+		return fmt.Errorf("failed to snooze all notifications: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), map[string]any{
+		"success":        true,
+		"action":         "snooze-all",
+		"snoozedUntilAt": until.Format(time.RFC3339),
+	}, true)
+}

--- a/cmd/linear/commands/notification/unsnooze_all.go
+++ b/cmd/linear/commands/notification/unsnooze_all.go
@@ -1,0 +1,57 @@
+package notification
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// NewUnsnoozeAllCommand creates the notification unsnooze-all command.
+func NewUnsnoozeAllCommand(clientFactory cli.ClientFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unsnooze-all",
+		Short: "Unsnooze all notifications for an entity",
+		Long: `Unsnooze all previously snoozed notifications for a specific entity.
+
+Requires exactly one of: --issue, --project, --initiative, --notification
+
+Example: go-linear notification unsnooze-all --issue=ENG-123
+
+Related: notification_snooze-all, notification_archive-all`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFactory()
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			return runUnsnoozeAll(cmd, client)
+		},
+	}
+
+	addEntityFlags(cmd)
+	return cmd
+}
+
+func runUnsnoozeAll(cmd *cobra.Command, client *linear.Client) error {
+	ctx := cmd.Context()
+
+	input, err := buildEntityInput(cmd)
+	if err != nil {
+		return err
+	}
+
+	if err := client.NotificationUnsnoozeAll(ctx, input, time.Now()); err != nil {
+		return fmt.Errorf("failed to unsnooze all notifications: %w", err)
+	}
+
+	return formatter.FormatJSON(cmd.OutOrStdout(), map[string]any{
+		"success": true,
+		"action":  "unsnooze-all",
+	}, true)
+}

--- a/cmd/linear/commands/notification/unsnooze_all.go
+++ b/cmd/linear/commands/notification/unsnooze_all.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
 	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/resolver"
 	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
 )
 
@@ -40,8 +41,9 @@ Related: notification_snooze-all, notification_archive-all`,
 
 func runUnsnoozeAll(cmd *cobra.Command, client *linear.Client) error {
 	ctx := cmd.Context()
+	res := resolver.New(client)
 
-	input, err := buildEntityInput(cmd)
+	input, err := buildEntityInput(cmd, ctx, res)
 	if err != nil {
 		return err
 	}

--- a/internal/dateparser/parser.go
+++ b/internal/dateparser/parser.go
@@ -92,7 +92,7 @@ func (p Parser) Parse(input string) (time.Time, error) {
 //
 // For duration formats ("7d", "2w", "3m"), the duration is added to now.
 // Use this for snooze/deadline inputs where "3d" means "3 days from now".
-// Unlike Parse, "yesterday" is rejected as it is never a future date.
+// Unlike Parse, "today" and "yesterday" are rejected as non-future dates.
 func (p Parser) ParseFuture(input string) (time.Time, error) {
 	if input == "" {
 		return time.Time{}, fmt.Errorf("empty date string")

--- a/internal/dateparser/parser.go
+++ b/internal/dateparser/parser.go
@@ -112,7 +112,7 @@ func (p Parser) ParseFuture(input string) (time.Time, error) {
 	now := time.Now().UTC()
 	switch strings.ToLower(input) {
 	case "today":
-		return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC), nil
+		return time.Time{}, fmt.Errorf("'today' is ambiguous as a future date; use 'tomorrow' or a duration like '1d'")
 	case "yesterday":
 		return time.Time{}, fmt.Errorf("'yesterday' is not a future date")
 	case "tomorrow":

--- a/internal/dateparser/parser.go
+++ b/internal/dateparser/parser.go
@@ -88,6 +88,67 @@ func (p Parser) Parse(input string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("invalid date format: %s (supported: ISO8601, 'today', 'yesterday', '7d', '2w', '3m')", input)
 }
 
+// ParseFuture parses a date string treating durations as future offsets.
+//
+// Identical to Parse for absolute dates and named dates. For duration formats
+// ("7d", "2w", "3m"), the duration is added to now instead of subtracted.
+// Use this for snooze/deadline inputs where "3d" means "3 days from now".
+func (p Parser) ParseFuture(input string) (time.Time, error) {
+	if input == "" {
+		return time.Time{}, fmt.Errorf("empty date string")
+	}
+
+	// Try ISO 8601 date only
+	if t, err := time.Parse("2006-01-02", input); err == nil {
+		return t.UTC(), nil
+	}
+
+	// Try ISO 8601 with time
+	if t, err := time.Parse(time.RFC3339, input); err == nil {
+		return t.UTC(), nil
+	}
+
+	// Try named dates
+	now := time.Now().UTC()
+	switch strings.ToLower(input) {
+	case "today":
+		return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC), nil
+	case "yesterday":
+		yesterday := now.Add(-24 * time.Hour)
+		return time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), 0, 0, 0, 0, time.UTC), nil
+	case "tomorrow":
+		tomorrow := now.Add(24 * time.Hour)
+		return time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 0, 0, 0, 0, time.UTC), nil
+	}
+
+	// Try duration format (e.g., "7d", "2w", "3m") — future direction
+	if matches := durationRegex.FindStringSubmatch(input); matches != nil {
+		amount, err := strconv.Atoi(matches[1])
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid duration amount: %s", matches[1])
+		}
+
+		unit := matches[2]
+		var duration time.Duration
+
+		switch unit {
+		case "d":
+			duration = time.Duration(amount) * 24 * time.Hour
+		case "w":
+			duration = time.Duration(amount) * 7 * 24 * time.Hour
+		case "m":
+			duration = time.Duration(amount) * 30 * 24 * time.Hour
+		default:
+			return time.Time{}, fmt.Errorf("invalid duration unit: %s", unit)
+		}
+
+		result := now.Add(duration)
+		return time.Date(result.Year(), result.Month(), result.Day(), 0, 0, 0, 0, time.UTC), nil
+	}
+
+	return time.Time{}, fmt.Errorf("invalid date format: %s (supported: ISO8601, 'today', 'yesterday', '7d', '2w', '3m')", input)
+}
+
 // MustParse parses a date string and panics on error.
 // Useful for testing and initialization.
 func (p Parser) MustParse(input string) time.Time {

--- a/internal/dateparser/parser.go
+++ b/internal/dateparser/parser.go
@@ -93,6 +93,8 @@ func (p Parser) Parse(input string) (time.Time, error) {
 // For duration formats ("7d", "2w", "3m"), the duration is added to now.
 // Use this for snooze/deadline inputs where "3d" means "3 days from now".
 // Unlike Parse, "today" and "yesterday" are rejected as non-future dates.
+// Note: ISO 8601 absolute dates are accepted as-is without futurity checks;
+// callers are responsible for validating that the result is in the future.
 func (p Parser) ParseFuture(input string) (time.Time, error) {
 	if input == "" {
 		return time.Time{}, fmt.Errorf("empty date string")

--- a/internal/dateparser/parser.go
+++ b/internal/dateparser/parser.go
@@ -90,9 +90,9 @@ func (p Parser) Parse(input string) (time.Time, error) {
 
 // ParseFuture parses a date string treating durations as future offsets.
 //
-// Identical to Parse for absolute dates and named dates. For duration formats
-// ("7d", "2w", "3m"), the duration is added to now instead of subtracted.
+// For duration formats ("7d", "2w", "3m"), the duration is added to now.
 // Use this for snooze/deadline inputs where "3d" means "3 days from now".
+// Unlike Parse, "yesterday" is rejected as it is never a future date.
 func (p Parser) ParseFuture(input string) (time.Time, error) {
 	if input == "" {
 		return time.Time{}, fmt.Errorf("empty date string")
@@ -114,8 +114,7 @@ func (p Parser) ParseFuture(input string) (time.Time, error) {
 	case "today":
 		return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC), nil
 	case "yesterday":
-		yesterday := now.Add(-24 * time.Hour)
-		return time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), 0, 0, 0, 0, time.UTC), nil
+		return time.Time{}, fmt.Errorf("'yesterday' is not a future date")
 	case "tomorrow":
 		tomorrow := now.Add(24 * time.Hour)
 		return time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 0, 0, 0, 0, time.UTC), nil
@@ -142,11 +141,10 @@ func (p Parser) ParseFuture(input string) (time.Time, error) {
 			return time.Time{}, fmt.Errorf("invalid duration unit: %s", unit)
 		}
 
-		result := now.Add(duration)
-		return time.Date(result.Year(), result.Month(), result.Day(), 0, 0, 0, 0, time.UTC), nil
+		return now.Add(duration), nil
 	}
 
-	return time.Time{}, fmt.Errorf("invalid date format: %s (supported: ISO8601, 'today', 'yesterday', '7d', '2w', '3m')", input)
+	return time.Time{}, fmt.Errorf("invalid date format: %s (supported: ISO8601, 'tomorrow', '3d', '2w', '3m')", input)
 }
 
 // MustParse parses a date string and panics on error.

--- a/internal/dateparser/parser_test.go
+++ b/internal/dateparser/parser_test.go
@@ -142,6 +142,75 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestParseFuture(t *testing.T) {
+	p := New()
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+		check   func(t *testing.T, result time.Time)
+	}{
+		{
+			name:    "3 days from now",
+			input:   "3d",
+			wantErr: false,
+			check: func(t *testing.T, result time.Time) {
+				threeDays := now.Add(3 * 24 * time.Hour)
+				if result.Year() != threeDays.Year() || result.Month() != threeDays.Month() || result.Day() != threeDays.Day() {
+					t.Errorf("ParseFuture('3d') = %v, want 3 days from now", result)
+				}
+			},
+		},
+		{
+			name:    "2 weeks from now",
+			input:   "2w",
+			wantErr: false,
+			check: func(t *testing.T, result time.Time) {
+				twoWeeks := now.Add(14 * 24 * time.Hour)
+				if result.Year() != twoWeeks.Year() || result.Month() != twoWeeks.Month() || result.Day() != twoWeeks.Day() {
+					t.Errorf("ParseFuture('2w') = %v, want 2 weeks from now", result)
+				}
+			},
+		},
+		{
+			name:    "ISO date unchanged",
+			input:   "2025-12-10",
+			wantErr: false,
+			check: func(t *testing.T, result time.Time) {
+				if result.Year() != 2025 || result.Month() != 12 || result.Day() != 10 {
+					t.Errorf("ParseFuture() = %v, want 2025-12-10", result)
+				}
+			},
+		},
+		{
+			name:    "tomorrow unchanged",
+			input:   "tomorrow",
+			wantErr: false,
+			check: func(t *testing.T, result time.Time) {
+				tomorrow := now.Add(24 * time.Hour)
+				if result.Year() != tomorrow.Year() || result.Month() != tomorrow.Month() || result.Day() != tomorrow.Day() {
+					t.Errorf("ParseFuture('tomorrow') = %v, want tomorrow", result)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := p.ParseFuture(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseFuture() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && tt.check != nil {
+				tt.check(t, result)
+			}
+		})
+	}
+}
+
 func TestMustParse(t *testing.T) {
 	p := New()
 

--- a/internal/dateparser/parser_test.go
+++ b/internal/dateparser/parser_test.go
@@ -184,6 +184,11 @@ func TestParseFuture(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "today is rejected",
+			input:   "today",
+			wantErr: true,
+		},
+		{
 			name:    "ISO date unchanged",
 			input:   "2025-12-10",
 			wantErr: false,

--- a/internal/dateparser/parser_test.go
+++ b/internal/dateparser/parser_test.go
@@ -189,12 +189,11 @@ func TestParseFuture(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "ISO date unchanged",
-			input:   "2025-12-10",
-			wantErr: false,
+			name:  "ISO date accepted as-is (futurity not checked)",
+			input: "2099-01-01",
 			check: func(t *testing.T, result time.Time) {
-				if result.Year() != 2025 || result.Month() != 12 || result.Day() != 10 {
-					t.Errorf("ParseFuture() = %v, want 2025-12-10", result)
+				if result.Year() != 2099 || result.Month() != 1 || result.Day() != 1 {
+					t.Errorf("ParseFuture() = %v, want 2099-01-01", result)
 				}
 			},
 		},

--- a/internal/dateparser/parser_test.go
+++ b/internal/dateparser/parser_test.go
@@ -161,6 +161,10 @@ func TestParseFuture(t *testing.T) {
 				if result.Year() != threeDays.Year() || result.Month() != threeDays.Month() || result.Day() != threeDays.Day() {
 					t.Errorf("ParseFuture('3d') = %v, want 3 days from now", result)
 				}
+				// Time-of-day should be preserved, not truncated to midnight.
+				if result.Hour() == 0 && result.Minute() == 0 && result.Second() == 0 && now.Hour() != 0 {
+					t.Errorf("ParseFuture('3d') truncated to midnight; got %v", result)
+				}
 			},
 		},
 		{
@@ -173,6 +177,11 @@ func TestParseFuture(t *testing.T) {
 					t.Errorf("ParseFuture('2w') = %v, want 2 weeks from now", result)
 				}
 			},
+		},
+		{
+			name:    "yesterday is rejected",
+			input:   "yesterday",
+			wantErr: true,
 		},
 		{
 			name:    "ISO date unchanged",

--- a/internal/graphql/client.go
+++ b/internal/graphql/client.go
@@ -82,6 +82,11 @@ type LinearGraphQLClient interface {
 	NotificationSubscriptionCreate(ctx context.Context, input NotificationSubscriptionCreateInput, interceptors ...clientv2.RequestInterceptor) (*NotificationSubscriptionCreate, error)
 	NotificationSubscriptionDelete(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*NotificationSubscriptionDelete, error)
 	UnarchiveNotification(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*UnarchiveNotification, error)
+	NotificationArchiveAll(ctx context.Context, input NotificationEntityInput, interceptors ...clientv2.RequestInterceptor) (*NotificationArchiveAll, error)
+	NotificationMarkReadAll(ctx context.Context, input NotificationEntityInput, readAt time.Time, interceptors ...clientv2.RequestInterceptor) (*NotificationMarkReadAll, error)
+	NotificationMarkUnreadAll(ctx context.Context, input NotificationEntityInput, interceptors ...clientv2.RequestInterceptor) (*NotificationMarkUnreadAll, error)
+	NotificationSnoozeAll(ctx context.Context, input NotificationEntityInput, snoozedUntilAt time.Time, interceptors ...clientv2.RequestInterceptor) (*NotificationSnoozeAll, error)
+	NotificationUnsnoozeAll(ctx context.Context, input NotificationEntityInput, unsnoozedAt time.Time, interceptors ...clientv2.RequestInterceptor) (*NotificationUnsnoozeAll, error)
 	ProjectMilestoneCreate(ctx context.Context, input ProjectMilestoneCreateInput, interceptors ...clientv2.RequestInterceptor) (*ProjectMilestoneCreate, error)
 	ProjectMilestoneUpdate(ctx context.Context, id string, input ProjectMilestoneUpdateInput, interceptors ...clientv2.RequestInterceptor) (*ProjectMilestoneUpdate, error)
 	ProjectMilestoneDelete(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*ProjectMilestoneDelete, error)
@@ -5607,6 +5612,61 @@ func (t *UnarchiveNotification_NotificationUnarchive) GetSuccess() bool {
 	return t.Success
 }
 
+type NotificationArchiveAll_NotificationArchiveAll struct {
+	Success bool "json:\"success\" graphql:\"success\""
+}
+
+func (t *NotificationArchiveAll_NotificationArchiveAll) GetSuccess() bool {
+	if t == nil {
+		t = &NotificationArchiveAll_NotificationArchiveAll{}
+	}
+	return t.Success
+}
+
+type NotificationMarkReadAll_NotificationMarkReadAll struct {
+	Success bool "json:\"success\" graphql:\"success\""
+}
+
+func (t *NotificationMarkReadAll_NotificationMarkReadAll) GetSuccess() bool {
+	if t == nil {
+		t = &NotificationMarkReadAll_NotificationMarkReadAll{}
+	}
+	return t.Success
+}
+
+type NotificationMarkUnreadAll_NotificationMarkUnreadAll struct {
+	Success bool "json:\"success\" graphql:\"success\""
+}
+
+func (t *NotificationMarkUnreadAll_NotificationMarkUnreadAll) GetSuccess() bool {
+	if t == nil {
+		t = &NotificationMarkUnreadAll_NotificationMarkUnreadAll{}
+	}
+	return t.Success
+}
+
+type NotificationSnoozeAll_NotificationSnoozeAll struct {
+	Success bool "json:\"success\" graphql:\"success\""
+}
+
+func (t *NotificationSnoozeAll_NotificationSnoozeAll) GetSuccess() bool {
+	if t == nil {
+		t = &NotificationSnoozeAll_NotificationSnoozeAll{}
+	}
+	return t.Success
+}
+
+type NotificationUnsnoozeAll_NotificationUnsnoozeAll struct {
+	Success bool "json:\"success\" graphql:\"success\""
+}
+
+func (t *NotificationUnsnoozeAll_NotificationUnsnoozeAll) GetSuccess() bool {
+	if t == nil {
+		t = &NotificationUnsnoozeAll_NotificationUnsnoozeAll{}
+	}
+	return t.Success
+}
+
 type ProjectMilestoneCreate_ProjectMilestoneCreate_ProjectMilestone_Project struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
@@ -9859,6 +9919,61 @@ func (t *UnarchiveNotification) GetNotificationUnarchive() *UnarchiveNotificatio
 	return &t.NotificationUnarchive
 }
 
+type NotificationArchiveAll struct {
+	NotificationArchiveAll NotificationArchiveAll_NotificationArchiveAll "json:\"notificationArchiveAll\" graphql:\"notificationArchiveAll\""
+}
+
+func (t *NotificationArchiveAll) GetNotificationArchiveAll() *NotificationArchiveAll_NotificationArchiveAll {
+	if t == nil {
+		t = &NotificationArchiveAll{}
+	}
+	return &t.NotificationArchiveAll
+}
+
+type NotificationMarkReadAll struct {
+	NotificationMarkReadAll NotificationMarkReadAll_NotificationMarkReadAll "json:\"notificationMarkReadAll\" graphql:\"notificationMarkReadAll\""
+}
+
+func (t *NotificationMarkReadAll) GetNotificationMarkReadAll() *NotificationMarkReadAll_NotificationMarkReadAll {
+	if t == nil {
+		t = &NotificationMarkReadAll{}
+	}
+	return &t.NotificationMarkReadAll
+}
+
+type NotificationMarkUnreadAll struct {
+	NotificationMarkUnreadAll NotificationMarkUnreadAll_NotificationMarkUnreadAll "json:\"notificationMarkUnreadAll\" graphql:\"notificationMarkUnreadAll\""
+}
+
+func (t *NotificationMarkUnreadAll) GetNotificationMarkUnreadAll() *NotificationMarkUnreadAll_NotificationMarkUnreadAll {
+	if t == nil {
+		t = &NotificationMarkUnreadAll{}
+	}
+	return &t.NotificationMarkUnreadAll
+}
+
+type NotificationSnoozeAll struct {
+	NotificationSnoozeAll NotificationSnoozeAll_NotificationSnoozeAll "json:\"notificationSnoozeAll\" graphql:\"notificationSnoozeAll\""
+}
+
+func (t *NotificationSnoozeAll) GetNotificationSnoozeAll() *NotificationSnoozeAll_NotificationSnoozeAll {
+	if t == nil {
+		t = &NotificationSnoozeAll{}
+	}
+	return &t.NotificationSnoozeAll
+}
+
+type NotificationUnsnoozeAll struct {
+	NotificationUnsnoozeAll NotificationUnsnoozeAll_NotificationUnsnoozeAll "json:\"notificationUnsnoozeAll\" graphql:\"notificationUnsnoozeAll\""
+}
+
+func (t *NotificationUnsnoozeAll) GetNotificationUnsnoozeAll() *NotificationUnsnoozeAll_NotificationUnsnoozeAll {
+	if t == nil {
+		t = &NotificationUnsnoozeAll{}
+	}
+	return &t.NotificationUnsnoozeAll
+}
+
 type ProjectMilestoneCreate struct {
 	ProjectMilestoneCreate ProjectMilestoneCreate_ProjectMilestoneCreate "json:\"projectMilestoneCreate\" graphql:\"projectMilestoneCreate\""
 }
@@ -12830,6 +12945,129 @@ func (c *Client) UnarchiveNotification(ctx context.Context, id string, intercept
 	return &res, nil
 }
 
+const NotificationArchiveAllDocument = `mutation NotificationArchiveAll ($input: NotificationEntityInput!) {
+	notificationArchiveAll(input: $input) {
+		success
+	}
+}
+`
+
+func (c *Client) NotificationArchiveAll(ctx context.Context, input NotificationEntityInput, interceptors ...clientv2.RequestInterceptor) (*NotificationArchiveAll, error) {
+	vars := map[string]any{
+		"input": input,
+	}
+
+	var res NotificationArchiveAll
+	if err := c.Client.Post(ctx, "NotificationArchiveAll", NotificationArchiveAllDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const NotificationMarkReadAllDocument = `mutation NotificationMarkReadAll ($input: NotificationEntityInput!, $readAt: DateTime!) {
+	notificationMarkReadAll(input: $input, readAt: $readAt) {
+		success
+	}
+}
+`
+
+func (c *Client) NotificationMarkReadAll(ctx context.Context, input NotificationEntityInput, readAt time.Time, interceptors ...clientv2.RequestInterceptor) (*NotificationMarkReadAll, error) {
+	vars := map[string]any{
+		"input":  input,
+		"readAt": readAt,
+	}
+
+	var res NotificationMarkReadAll
+	if err := c.Client.Post(ctx, "NotificationMarkReadAll", NotificationMarkReadAllDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const NotificationMarkUnreadAllDocument = `mutation NotificationMarkUnreadAll ($input: NotificationEntityInput!) {
+	notificationMarkUnreadAll(input: $input) {
+		success
+	}
+}
+`
+
+func (c *Client) NotificationMarkUnreadAll(ctx context.Context, input NotificationEntityInput, interceptors ...clientv2.RequestInterceptor) (*NotificationMarkUnreadAll, error) {
+	vars := map[string]any{
+		"input": input,
+	}
+
+	var res NotificationMarkUnreadAll
+	if err := c.Client.Post(ctx, "NotificationMarkUnreadAll", NotificationMarkUnreadAllDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const NotificationSnoozeAllDocument = `mutation NotificationSnoozeAll ($input: NotificationEntityInput!, $snoozedUntilAt: DateTime!) {
+	notificationSnoozeAll(input: $input, snoozedUntilAt: $snoozedUntilAt) {
+		success
+	}
+}
+`
+
+func (c *Client) NotificationSnoozeAll(ctx context.Context, input NotificationEntityInput, snoozedUntilAt time.Time, interceptors ...clientv2.RequestInterceptor) (*NotificationSnoozeAll, error) {
+	vars := map[string]any{
+		"input":          input,
+		"snoozedUntilAt": snoozedUntilAt,
+	}
+
+	var res NotificationSnoozeAll
+	if err := c.Client.Post(ctx, "NotificationSnoozeAll", NotificationSnoozeAllDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const NotificationUnsnoozeAllDocument = `mutation NotificationUnsnoozeAll ($input: NotificationEntityInput!, $unsnoozedAt: DateTime!) {
+	notificationUnsnoozeAll(input: $input, unsnoozedAt: $unsnoozedAt) {
+		success
+	}
+}
+`
+
+func (c *Client) NotificationUnsnoozeAll(ctx context.Context, input NotificationEntityInput, unsnoozedAt time.Time, interceptors ...clientv2.RequestInterceptor) (*NotificationUnsnoozeAll, error) {
+	vars := map[string]any{
+		"input":       input,
+		"unsnoozedAt": unsnoozedAt,
+	}
+
+	var res NotificationUnsnoozeAll
+	if err := c.Client.Post(ctx, "NotificationUnsnoozeAll", NotificationUnsnoozeAllDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
 const ProjectMilestoneCreateDocument = `mutation ProjectMilestoneCreate ($input: ProjectMilestoneCreateInput!) {
 	projectMilestoneCreate(input: $input) {
 		success
@@ -14411,6 +14649,11 @@ var DocumentOperationNames = map[string]string{
 	NotificationSubscriptionCreateDocument: "NotificationSubscriptionCreate",
 	NotificationSubscriptionDeleteDocument: "NotificationSubscriptionDelete",
 	UnarchiveNotificationDocument:          "UnarchiveNotification",
+	NotificationArchiveAllDocument:         "NotificationArchiveAll",
+	NotificationMarkReadAllDocument:        "NotificationMarkReadAll",
+	NotificationMarkUnreadAllDocument:      "NotificationMarkUnreadAll",
+	NotificationSnoozeAllDocument:          "NotificationSnoozeAll",
+	NotificationUnsnoozeAllDocument:        "NotificationUnsnoozeAll",
 	ProjectMilestoneCreateDocument:         "ProjectMilestoneCreate",
 	ProjectMilestoneUpdateDocument:         "ProjectMilestoneUpdate",
 	ProjectMilestoneDeleteDocument:         "ProjectMilestoneDelete",

--- a/pkg/linear/client_notification_bulk.go
+++ b/pkg/linear/client_notification_bulk.go
@@ -1,0 +1,126 @@
+package linear
+
+import (
+	"context"
+	"time"
+
+	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
+)
+
+// NotificationArchiveAll archives all notifications for a given entity.
+//
+// Parameters:
+//   - input: Entity to archive notifications for (issueId, projectId, etc.)
+//
+// Returns:
+//   - nil: Notifications successfully archived
+//   - error: Non-nil if operation fails
+//
+// Permissions Required: Write
+//
+// Related: [NotificationArchive], [NotificationMarkReadAll]
+func (c *Client) NotificationArchiveAll(ctx context.Context, input intgraphql.NotificationEntityInput) error {
+	resp, err := c.gqlClient.NotificationArchiveAll(ctx, input)
+	if err != nil {
+		return wrapGraphQLError("NotificationArchiveAll", err)
+	}
+	if !resp.NotificationArchiveAll.Success {
+		return errMutationFailed("NotificationArchiveAll")
+	}
+	return nil
+}
+
+// NotificationMarkReadAll marks all notifications as read for a given entity.
+//
+// Parameters:
+//   - input: Entity to mark notifications for
+//   - readAt: Time to set as read timestamp
+//
+// Returns:
+//   - nil: Notifications successfully marked as read
+//   - error: Non-nil if operation fails
+//
+// Permissions Required: Write
+//
+// Related: [NotificationMarkUnreadAll], [NotificationUpdate]
+func (c *Client) NotificationMarkReadAll(ctx context.Context, input intgraphql.NotificationEntityInput, readAt time.Time) error {
+	resp, err := c.gqlClient.NotificationMarkReadAll(ctx, input, readAt)
+	if err != nil {
+		return wrapGraphQLError("NotificationMarkReadAll", err)
+	}
+	if !resp.NotificationMarkReadAll.Success {
+		return errMutationFailed("NotificationMarkReadAll")
+	}
+	return nil
+}
+
+// NotificationMarkUnreadAll marks all notifications as unread for a given entity.
+//
+// Parameters:
+//   - input: Entity to mark notifications for
+//
+// Returns:
+//   - nil: Notifications successfully marked as unread
+//   - error: Non-nil if operation fails
+//
+// Permissions Required: Write
+//
+// Related: [NotificationMarkReadAll], [NotificationUpdate]
+func (c *Client) NotificationMarkUnreadAll(ctx context.Context, input intgraphql.NotificationEntityInput) error {
+	resp, err := c.gqlClient.NotificationMarkUnreadAll(ctx, input)
+	if err != nil {
+		return wrapGraphQLError("NotificationMarkUnreadAll", err)
+	}
+	if !resp.NotificationMarkUnreadAll.Success {
+		return errMutationFailed("NotificationMarkUnreadAll")
+	}
+	return nil
+}
+
+// NotificationSnoozeAll snoozes all notifications for a given entity.
+//
+// Parameters:
+//   - input: Entity to snooze notifications for
+//   - snoozedUntilAt: Time until notifications are snoozed
+//
+// Returns:
+//   - nil: Notifications successfully snoozed
+//   - error: Non-nil if operation fails
+//
+// Permissions Required: Write
+//
+// Related: [NotificationUnsnoozeAll], [NotificationUpdate]
+func (c *Client) NotificationSnoozeAll(ctx context.Context, input intgraphql.NotificationEntityInput, snoozedUntilAt time.Time) error {
+	resp, err := c.gqlClient.NotificationSnoozeAll(ctx, input, snoozedUntilAt)
+	if err != nil {
+		return wrapGraphQLError("NotificationSnoozeAll", err)
+	}
+	if !resp.NotificationSnoozeAll.Success {
+		return errMutationFailed("NotificationSnoozeAll")
+	}
+	return nil
+}
+
+// NotificationUnsnoozeAll unsnoozes all notifications for a given entity.
+//
+// Parameters:
+//   - input: Entity to unsnooze notifications for
+//   - unsnoozedAt: Time when the notification was unsnoozed
+//
+// Returns:
+//   - nil: Notifications successfully unsnoozed
+//   - error: Non-nil if operation fails
+//
+// Permissions Required: Write
+//
+// Related: [NotificationSnoozeAll], [NotificationUpdate]
+func (c *Client) NotificationUnsnoozeAll(ctx context.Context, input intgraphql.NotificationEntityInput, unsnoozedAt time.Time) error {
+	resp, err := c.gqlClient.NotificationUnsnoozeAll(ctx, input, unsnoozedAt)
+	if err != nil {
+		return wrapGraphQLError("NotificationUnsnoozeAll", err)
+	}
+	if !resp.NotificationUnsnoozeAll.Success {
+		return errMutationFailed("NotificationUnsnoozeAll")
+	}
+	return nil
+}

--- a/queries/mutations/notifications.graphql
+++ b/queries/mutations/notifications.graphql
@@ -37,3 +37,33 @@ mutation UnarchiveNotification($id: String!) {
     success
   }
 }
+
+mutation NotificationArchiveAll($input: NotificationEntityInput!) {
+  notificationArchiveAll(input: $input) {
+    success
+  }
+}
+
+mutation NotificationMarkReadAll($input: NotificationEntityInput!, $readAt: DateTime!) {
+  notificationMarkReadAll(input: $input, readAt: $readAt) {
+    success
+  }
+}
+
+mutation NotificationMarkUnreadAll($input: NotificationEntityInput!) {
+  notificationMarkUnreadAll(input: $input) {
+    success
+  }
+}
+
+mutation NotificationSnoozeAll($input: NotificationEntityInput!, $snoozedUntilAt: DateTime!) {
+  notificationSnoozeAll(input: $input, snoozedUntilAt: $snoozedUntilAt) {
+    success
+  }
+}
+
+mutation NotificationUnsnoozeAll($input: NotificationEntityInput!, $unsnoozedAt: DateTime!) {
+  notificationUnsnoozeAll(input: $input, unsnoozedAt: $unsnoozedAt) {
+    success
+  }
+}


### PR DESCRIPTION
## Summary

- Adds \`--estimate\` flag to \`issue update\`, matching the flag already present in \`issue create\`
- Wires estimate through both the standard \`IssueUpdateInput\` path and the nullable \`IssueUpdateNullableInput\` path
- The Linear GraphQL \`issueUpdate\` mutation already accepts \`estimate\`; this just exposes it in the CLI

Closes #71