### PR TITLE
fix(mcp): normalize double-encoded flags from MCP client

### DIFF
--- a/cmd/linear/main.go
+++ b/cmd/linear/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"os"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/njayp/ophis"
 
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands"
@@ -26,13 +27,9 @@ import (
 func main() {
 	rootCmd := commands.NewRootCommand()
 
-	// Add ophis MCP integration
-	// This single line exposes the entire CLI as an MCP server!
-	// Ophis recursively walks the Cobra command tree and generates:
-	// - JSON schemas from command flags
-	// - MCP tool definitions
-	// - Tool execution by spawning CLI subprocesses
-	rootCmd.AddCommand(ophis.Command(nil))
+	rootCmd.AddCommand(ophis.Command(&ophis.Config{
+		Transport: &fixFlagsTransport{inner: &mcp.StdioTransport{}},
+	}))
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/linear/mcp_transport.go
+++ b/cmd/linear/mcp_transport.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// fixFlagsTransport wraps an mcp.Transport to normalize double-encoded flags.
+//
+// Some MCP clients (e.g. Claude Code) intermittently JSON-encode the
+// `arguments.flags` value twice, sending a string where the schema expects an
+// object. This transport intercepts tools/call requests before schema validation
+// and decodes the inner string back into an object.
+type fixFlagsTransport struct {
+	inner mcp.Transport
+}
+
+func (t *fixFlagsTransport) Connect(ctx context.Context) (mcp.Connection, error) {
+	conn, err := t.inner.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &fixFlagsConn{delegate: conn}, nil
+}
+
+type fixFlagsConn struct {
+	delegate mcp.Connection
+}
+
+func (c *fixFlagsConn) SessionID() string                          { return c.delegate.SessionID() }
+func (c *fixFlagsConn) Write(ctx context.Context, msg jsonrpc.Message) error {
+	return c.delegate.Write(ctx, msg)
+}
+func (c *fixFlagsConn) Close() error { return c.delegate.Close() }
+
+func (c *fixFlagsConn) Read(ctx context.Context) (jsonrpc.Message, error) {
+	msg, err := c.delegate.Read(ctx)
+	if err != nil {
+		return msg, err
+	}
+
+	req, ok := msg.(*jsonrpc.Request)
+	if !ok || req.Method != "tools/call" {
+		return msg, nil
+	}
+
+	fixed, err := fixDoubleEncodedFlags(req.Params)
+	if err != nil || fixed == nil {
+		return msg, nil
+	}
+	req.Params = fixed
+	return req, nil
+}
+
+// fixDoubleEncodedFlags detects and fixes double-encoded flags in tools/call params.
+// Returns nil if no fix was needed, or the corrected params if a fix was applied.
+func fixDoubleEncodedFlags(raw json.RawMessage) (json.RawMessage, error) {
+	var params struct {
+		Name      string                     `json:"name"`
+		Arguments map[string]json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, err
+	}
+
+	flagsRaw, ok := params.Arguments["flags"]
+	if !ok {
+		return nil, nil
+	}
+
+	// Check if flags is a JSON string (double-encoded)
+	var flagsStr string
+	if err := json.Unmarshal(flagsRaw, &flagsStr); err != nil {
+		return nil, nil // flags is already an object, no fix needed
+	}
+
+	// Decode the inner JSON string into an object
+	var flagsObj json.RawMessage
+	if err := json.Unmarshal([]byte(flagsStr), &flagsObj); err != nil {
+		return nil, nil // inner value isn't valid JSON, leave it alone
+	}
+
+	params.Arguments["flags"] = flagsObj
+	return json.Marshal(params)
+}

--- a/cmd/linear/mcp_transport.go
+++ b/cmd/linear/mcp_transport.go
@@ -30,7 +30,7 @@ type fixFlagsConn struct {
 	delegate mcp.Connection
 }
 
-func (c *fixFlagsConn) SessionID() string                          { return c.delegate.SessionID() }
+func (c *fixFlagsConn) SessionID() string { return c.delegate.SessionID() }
 func (c *fixFlagsConn) Write(ctx context.Context, msg jsonrpc.Message) error {
 	return c.delegate.Write(ctx, msg)
 }
@@ -47,8 +47,8 @@ func (c *fixFlagsConn) Read(ctx context.Context) (jsonrpc.Message, error) {
 		return msg, nil
 	}
 
-	fixed, err := fixDoubleEncodedFlags(req.Params)
-	if err != nil || fixed == nil {
+	fixed, _ := fixDoubleEncodedFlags(req.Params)
+	if fixed == nil {
 		return msg, nil
 	}
 	req.Params = fixed
@@ -71,18 +71,36 @@ func fixDoubleEncodedFlags(raw json.RawMessage) (json.RawMessage, error) {
 		return nil, nil
 	}
 
-	// Check if flags is a JSON string (double-encoded)
-	var flagsStr string
-	if err := json.Unmarshal(flagsRaw, &flagsStr); err != nil {
-		return nil, nil // flags is already an object, no fix needed
+	// If flags is not a JSON string, it's already an object — no fix needed.
+	flagsStr, ok := asJSONString(flagsRaw)
+	if !ok {
+		return nil, nil
 	}
 
-	// Decode the inner JSON string into an object
-	var flagsObj json.RawMessage
-	if err := json.Unmarshal([]byte(flagsStr), &flagsObj); err != nil {
-		return nil, nil // inner value isn't valid JSON, leave it alone
+	// Decode the inner JSON string into an object; leave it alone if invalid.
+	flagsObj, ok := asJSONObject([]byte(flagsStr))
+	if !ok {
+		return nil, nil
 	}
 
 	params.Arguments["flags"] = flagsObj
 	return json.Marshal(params)
+}
+
+// asJSONString returns the string value if raw is a JSON string, else ("", false).
+func asJSONString(raw json.RawMessage) (string, bool) {
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return "", false
+	}
+	return s, true
+}
+
+// asJSONObject returns raw as a RawMessage if it is valid JSON object/array, else (nil, false).
+func asJSONObject(data []byte) (json.RawMessage, bool) {
+	var obj json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, false
+	}
+	return obj, true
 }

--- a/cmd/linear/mcp_transport_test.go
+++ b/cmd/linear/mcp_transport_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFixDoubleEncodedFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantNil bool // true = no fix needed
+		wantOut string
+	}{
+		{
+			name:    "already an object - no fix",
+			input:   `{"name":"go-linear_issue_update","arguments":{"flags":{"state":"Done"}}}`,
+			wantNil: true,
+		},
+		{
+			name:    "double-encoded flags - fixed",
+			input:   `{"name":"go-linear_issue_update","arguments":{"flags":"{\"state\":\"Done\"}"}}`,
+			wantOut: `{"name":"go-linear_issue_update","arguments":{"flags":{"state":"Done"}}}`,
+		},
+		{
+			name:    "no flags key - no fix",
+			input:   `{"name":"go-linear_issue_list","arguments":{}}`,
+			wantNil: true,
+		},
+		{
+			name:    "double-encoded with multiple fields",
+			input:   `{"name":"go-linear_issue_update","arguments":{"flags":"{\"issue\":\"ENG-1\",\"body\":\"test\"}"}}`,
+			wantOut: `{"name":"go-linear_issue_update","arguments":{"flags":{"issue":"ENG-1","body":"test"}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := fixDoubleEncodedFlags(json.RawMessage(tt.input))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNil {
+				if result != nil {
+					t.Errorf("expected nil, got %s", result)
+				}
+				return
+			}
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			// Normalize by round-tripping through map to avoid key-order differences
+			var got, want map[string]any
+			if err := json.Unmarshal(result, &got); err != nil {
+				t.Fatalf("result is invalid JSON: %v", err)
+			}
+			if err := json.Unmarshal([]byte(tt.wantOut), &want); err != nil {
+				t.Fatalf("wantOut is invalid JSON: %v", err)
+			}
+			gotB, _ := json.Marshal(got)
+			wantB, _ := json.Marshal(want)
+			if string(gotB) != string(wantB) {
+				t.Errorf("got %s, want %s", gotB, wantB)
+			}
+		})
+	}
+}

--- a/cmd/linear/mcp_transport_test.go
+++ b/cmd/linear/mcp_transport_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 )
@@ -59,7 +60,7 @@ func TestFixDoubleEncodedFlags(t *testing.T) {
 			}
 			gotB, _ := json.Marshal(got)
 			wantB, _ := json.Marshal(want)
-			if string(gotB) != string(wantB) {
+			if !bytes.Equal(gotB, wantB) {
 				t.Errorf("got %s, want %s", gotB, wantB)
 			}
 		})


### PR DESCRIPTION
## Summary

- Claude Code's MCP client intermittently double-encodes `arguments.flags` as a JSON string instead of a JSON object, causing the go-sdk's schema validator to reject the request before ophis's handler runs
- Adds a `FixFlagsTransport` wrapper (same pattern as `mcp.LoggingTransport`) that intercepts `tools/call` requests on `Read` and unwraps double-encoded flags before they reach validation
- No ophis changes required; `Write`, `Close`, and `SessionID` are delegated automatically via embedded `mcp.Connection`

## Test plan

- [ ] `go test ./cmd/linear/...` passes
- [ ] `go-linear_comment_create` succeeds with `--issue` and `--body` flags
- [ ] `go-linear_issue_update --description` succeeds
- [ ] Read-only tools (`issue_list`, `issue_get`) unaffected

## Related

- Closes #75
- Upstream client bug: [anthropics/claude-code#3023](https://github.com/anthropics/claude-code/issues/3023), [#5504](https://github.com/anthropics/claude-code/issues/5504), [#4192](https://github.com/anthropics/claude-code/issues/4192)
- Adjacent ophis issue: [njayp/ophis#35](https://github.com/njayp/ophis/issues/35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)