### PR TITLE
Feat/issue estimate

### DIFF
--- a/cmd/linear/commands/issue/update.go
+++ b/cmd/linear/commands/issue/update.go
@@ -19,7 +19,7 @@ func NewUpdateCommand(clientFactory cli.ClientFactory) *cobra.Command {
 		Short: "Update an existing issue",
 		Long: `Update issue. Modifies existing data.
 
-Fields: --title, --description, --assignee (name/email/ID/'me'/'none'), --state, --priority (0-4), --cycle, --project, --parent, --due-date (YYYY-MM-DD or 'none'), --milestone (uuid or 'none'), --add-label, --remove-label, --link-pr
+Fields: --title, --description, --assignee (name/email/ID/'me'/'none'), --state, --priority (0-4), --estimate, --cycle, --project, --parent, --due-date (YYYY-MM-DD or 'none'), --milestone (uuid or 'none'), --add-label, --remove-label, --link-pr
 
 Example: go-linear issue update ENG-123 --state=Done --due-date=2025-03-01
 
@@ -48,6 +48,7 @@ Related: issue_get, issue_create`,
 	cmd.Flags().StringArray("add-label", []string{}, "Add labels (repeatable)")
 	cmd.Flags().StringArray("remove-label", []string{}, "Remove labels (repeatable)")
 	cmd.Flags().String("link-pr", "", "Link GitHub PR (format: owner/repo#number or full URL)")
+	cmd.Flags().Int("estimate", -1, "Story points/estimate (-1 = no change)")
 	cmd.Flags().String("due-date", "", "Due date (YYYY-MM-DD, use 'none' to remove)")
 	cmd.Flags().String("milestone", "", "Project milestone UUID (use 'none' to remove)")
 
@@ -137,6 +138,12 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 		}
 		p := int64(priority)
 		input.Priority = &p
+		updated = true
+	}
+
+	if estimate, _ := cmd.Flags().GetInt("estimate"); estimate >= 0 {
+		e := int64(estimate)
+		input.Estimate = &e
 		updated = true
 	}
 
@@ -328,6 +335,11 @@ func runUpdateWithNullable(cmd *cobra.Command, client *linear.Client, issueID st
 	if priority, _ := cmd.Flags().GetInt("priority"); priority >= 0 {
 		p := int64(priority)
 		input.Priority = &p
+	}
+
+	if estimate, _ := cmd.Flags().GetInt("estimate"); estimate >= 0 {
+		e := int64(estimate)
+		input.Estimate = &e
 	}
 
 	addLabels, _ := cmd.Flags().GetStringArray("add-label")

--- a/cmd/linear/commands/issue/update.go
+++ b/cmd/linear/commands/issue/update.go
@@ -2,10 +2,13 @@ package issue
 
 import (
 	"fmt"
+	"slices"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/chainguard-sandbox/go-linear/v2/internal/cli"
+	"github.com/chainguard-sandbox/go-linear/v2/internal/dateparser"
 	"github.com/chainguard-sandbox/go-linear/v2/internal/formatter"
 	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
 	"github.com/chainguard-sandbox/go-linear/v2/internal/resolver"
@@ -19,7 +22,7 @@ func NewUpdateCommand(clientFactory cli.ClientFactory) *cobra.Command {
 		Short: "Update an existing issue",
 		Long: `Update issue. Modifies existing data.
 
-Fields: --title, --description, --assignee (name/email/ID/'me'/'none'), --state, --priority (0-4), --estimate, --cycle, --project, --parent, --due-date (YYYY-MM-DD or 'none'), --milestone (uuid or 'none'), --add-label, --remove-label, --link-pr
+Fields: --title, --description, --assignee (name/email/ID/'me'/'none'), --state, --priority (0-4), --estimate, --team, --cycle, --project, --parent, --due-date (YYYY-MM-DD or 'none'), --milestone (uuid or 'none'), --snooze-until (duration or 'none'), --add-label, --remove-label, --add-subscriber, --remove-subscriber, --trash, --untrash, --link-pr
 
 Example: go-linear issue update ENG-123 --state=Done --due-date=2025-03-01
 
@@ -49,6 +52,12 @@ Related: issue_get, issue_create`,
 	cmd.Flags().StringArray("remove-label", []string{}, "Remove labels (repeatable)")
 	cmd.Flags().String("link-pr", "", "Link GitHub PR (format: owner/repo#number or full URL)")
 	cmd.Flags().Int("estimate", -1, "Story points/estimate (-1 = no change)")
+	cmd.Flags().String("team", "", "Move issue to a different team (name or ID)")
+	cmd.Flags().String("snooze-until", "", "Snooze issue in triage until date/duration (e.g. '3d', '2w', 'tomorrow', use 'none' to unsnooze)")
+	cmd.Flags().StringArray("add-subscriber", []string{}, "Add subscribers (name/email/ID, repeatable)")
+	cmd.Flags().StringArray("remove-subscriber", []string{}, "Remove subscribers (name/email/ID, repeatable)")
+	cmd.Flags().Bool("trash", false, "Move issue to trash")
+	cmd.Flags().Bool("untrash", false, "Restore issue from trash")
 	cmd.Flags().String("due-date", "", "Due date (YYYY-MM-DD, use 'none' to remove)")
 	cmd.Flags().String("milestone", "", "Project milestone UUID (use 'none' to remove)")
 
@@ -92,6 +101,11 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 	}
 	if cmd.Flags().Changed("milestone") {
 		if milestone, _ := cmd.Flags().GetString("milestone"); milestone == "none" {
+			needsNullable = true
+		}
+	}
+	if cmd.Flags().Changed("snooze-until") {
+		if s, _ := cmd.Flags().GetString("snooze-until"); s == "none" {
 			needsNullable = true
 		}
 	}
@@ -251,6 +265,63 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 			}
 			input.ProjectMilestoneID = &milestoneID
 		}
+		updated = true
+	}
+
+	if team, _ := cmd.Flags().GetString("team"); team != "" {
+		teamID, err := res.ResolveTeam(ctx, team)
+		if err != nil {
+			return fmt.Errorf("failed to resolve team: %w", err)
+		}
+		input.TeamID = &teamID
+		updated = true
+	}
+
+	if cmd.Flags().Changed("snooze-until") {
+		snoozeUntil, _ := cmd.Flags().GetString("snooze-until")
+		dp := dateparser.New()
+		t, err := dp.ParseFuture(snoozeUntil)
+		if err != nil {
+			return fmt.Errorf("invalid snooze-until: %w", err)
+		}
+		input.SnoozedUntilAt = &t
+		updated = true
+	}
+
+	addSubscribers, _ := cmd.Flags().GetStringArray("add-subscriber")
+	removeSubscribers, _ := cmd.Flags().GetStringArray("remove-subscriber")
+	if len(addSubscribers) > 0 || len(removeSubscribers) > 0 {
+		currentIDs, err := client.IssueSubscriberIDs(ctx, resolvedIssueID)
+		if err != nil {
+			return fmt.Errorf("failed to fetch current subscribers: %w", err)
+		}
+		for _, s := range addSubscribers {
+			id, err := res.ResolveUser(ctx, s)
+			if err != nil {
+				return fmt.Errorf("failed to resolve subscriber %q: %w", s, err)
+			}
+			if !slices.Contains(currentIDs, id) {
+				currentIDs = append(currentIDs, id)
+			}
+		}
+		for _, s := range removeSubscribers {
+			id, err := res.ResolveUser(ctx, s)
+			if err != nil {
+				return fmt.Errorf("failed to resolve subscriber %q: %w", s, err)
+			}
+			currentIDs = slices.DeleteFunc(currentIDs, func(x string) bool { return x == id })
+		}
+		input.SubscriberIds = currentIDs
+		updated = true
+	}
+
+	if trash, _ := cmd.Flags().GetBool("trash"); trash {
+		t := true
+		input.Trashed = &t
+		updated = true
+	} else if untrash, _ := cmd.Flags().GetBool("untrash"); untrash {
+		f := false
+		input.Trashed = &f
 		updated = true
 	}
 
@@ -430,6 +501,62 @@ func runUpdateWithNullable(cmd *cobra.Command, client *linear.Client, issueID st
 			}
 			input.ProjectMilestoneID = linear.NewValue(milestoneID)
 		}
+	}
+
+	if team, _ := cmd.Flags().GetString("team"); team != "" {
+		teamID, err := res.ResolveTeam(ctx, team)
+		if err != nil {
+			return fmt.Errorf("failed to resolve team: %w", err)
+		}
+		input.TeamID = &teamID
+	}
+
+	if cmd.Flags().Changed("snooze-until") {
+		snoozeUntil, _ := cmd.Flags().GetString("snooze-until")
+		if snoozeUntil == "none" {
+			input.SnoozedUntilAt = linear.NewNull[time.Time]()
+		} else {
+			dp := dateparser.New()
+			t, err := dp.ParseFuture(snoozeUntil)
+			if err != nil {
+				return fmt.Errorf("invalid snooze-until: %w", err)
+			}
+			input.SnoozedUntilAt = linear.NewValue(t)
+		}
+	}
+
+	addSubscribers, _ := cmd.Flags().GetStringArray("add-subscriber")
+	removeSubscribers, _ := cmd.Flags().GetStringArray("remove-subscriber")
+	if len(addSubscribers) > 0 || len(removeSubscribers) > 0 {
+		currentIDs, err := client.IssueSubscriberIDs(ctx, issueID)
+		if err != nil {
+			return fmt.Errorf("failed to fetch current subscribers: %w", err)
+		}
+		for _, s := range addSubscribers {
+			id, err := res.ResolveUser(ctx, s)
+			if err != nil {
+				return fmt.Errorf("failed to resolve subscriber %q: %w", s, err)
+			}
+			if !slices.Contains(currentIDs, id) {
+				currentIDs = append(currentIDs, id)
+			}
+		}
+		for _, s := range removeSubscribers {
+			id, err := res.ResolveUser(ctx, s)
+			if err != nil {
+				return fmt.Errorf("failed to resolve subscriber %q: %w", s, err)
+			}
+			currentIDs = slices.DeleteFunc(currentIDs, func(x string) bool { return x == id })
+		}
+		input.SubscriberIDs = currentIDs
+	}
+
+	if trash, _ := cmd.Flags().GetBool("trash"); trash {
+		t := true
+		input.Trashed = &t
+	} else if untrash, _ := cmd.Flags().GetBool("untrash"); untrash {
+		f := false
+		input.Trashed = &f
 	}
 
 	// Use nullable update method

--- a/cmd/linear/commands/issue/update.go
+++ b/cmd/linear/commands/issue/update.go
@@ -3,6 +3,7 @@ package issue
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -22,7 +23,7 @@ func NewUpdateCommand(clientFactory cli.ClientFactory) *cobra.Command {
 		Short: "Update an existing issue",
 		Long: `Update issue. Modifies existing data.
 
-Fields: --title, --description, --assignee (name/email/ID/'me'/'none'), --state, --priority (0-4), --estimate, --team, --cycle, --project, --parent, --due-date (YYYY-MM-DD or 'none'), --milestone (uuid or 'none'), --snooze-until (duration or 'none'), --add-label, --remove-label, --add-subscriber, --remove-subscriber, --trash, --untrash, --link-pr
+Fields: --title, --description, --assignee (name/email/ID/'me'/'none'), --state, --priority (0-4), --estimate (integer or 'none'), --team, --cycle, --project, --parent, --due-date (YYYY-MM-DD or 'none'), --milestone (uuid or 'none'), --snooze-until (duration or 'none'), --add-label, --remove-label, --add-subscriber, --remove-subscriber, --trash, --untrash, --link-pr
 
 Example: go-linear issue update ENG-123 --state=Done --due-date=2025-03-01
 
@@ -51,7 +52,7 @@ Related: issue_get, issue_create`,
 	cmd.Flags().StringArray("add-label", []string{}, "Add labels (repeatable)")
 	cmd.Flags().StringArray("remove-label", []string{}, "Remove labels (repeatable)")
 	cmd.Flags().String("link-pr", "", "Link GitHub PR (format: owner/repo#number or full URL)")
-	cmd.Flags().Int("estimate", -1, "Story points/estimate (-1 = no change)")
+	cmd.Flags().String("estimate", "", "Story points/estimate (integer, or 'none' to clear)")
 	cmd.Flags().String("team", "", "Move issue to a different team (name or ID)")
 	cmd.Flags().String("snooze-until", "", "Snooze issue in triage until date/duration (e.g. '3d', '2w', 'tomorrow', use 'none' to unsnooze)")
 	cmd.Flags().StringArray("add-subscriber", []string{}, "Add subscribers (name/email/ID, repeatable)")
@@ -110,6 +111,11 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 			needsNullable = true
 		}
 	}
+	if cmd.Flags().Changed("estimate") {
+		if e, _ := cmd.Flags().GetString("estimate"); e == "none" {
+			needsNullable = true
+		}
+	}
 	if cmd.Flags().Changed("snooze-until") {
 		if s, _ := cmd.Flags().GetString("snooze-until"); s == "none" {
 			needsNullable = true
@@ -161,8 +167,13 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 		updated = true
 	}
 
-	if estimate, _ := cmd.Flags().GetInt("estimate"); estimate >= 0 {
-		e := int64(estimate)
+	if cmd.Flags().Changed("estimate") {
+		estimateStr, _ := cmd.Flags().GetString("estimate")
+		n, err := strconv.Atoi(estimateStr)
+		if err != nil || n < 0 {
+			return fmt.Errorf("invalid estimate %q: must be a non-negative integer or 'none'", estimateStr)
+		}
+		e := int64(n)
 		input.Estimate = &e
 		updated = true
 	}
@@ -414,9 +425,18 @@ func runUpdateWithNullable(cmd *cobra.Command, client *linear.Client, issueID st
 		input.Priority = &p
 	}
 
-	if estimate, _ := cmd.Flags().GetInt("estimate"); estimate >= 0 {
-		e := int64(estimate)
-		input.Estimate = &e
+	if cmd.Flags().Changed("estimate") {
+		estimateStr, _ := cmd.Flags().GetString("estimate")
+		if estimateStr == "none" {
+			input.Estimate = linear.NewNull[int64]()
+		} else {
+			n, err := strconv.Atoi(estimateStr)
+			if err != nil || n < 0 {
+				return fmt.Errorf("invalid estimate %q: must be a non-negative integer or 'none'", estimateStr)
+			}
+			e := int64(n)
+			input.Estimate = linear.NewValue(e)
+		}
 	}
 
 	addLabels, _ := cmd.Flags().GetStringArray("add-label")
@@ -569,6 +589,18 @@ func runUpdateWithNullable(cmd *cobra.Command, client *linear.Client, issueID st
 	result, err := client.IssueUpdateNullable(ctx, issueID, input)
 	if err != nil {
 		return fmt.Errorf("failed to update issue: %w", err)
+	}
+
+	// Link GitHub PR if specified
+	if prURL, _ := cmd.Flags().GetString("link-pr"); prURL != "" {
+		fullURL := prURL
+		if !contains(prURL, "://") {
+			fullURL = "https://github.com/" + prURL
+		}
+		_, err := client.AttachmentLinkGitHubPR(ctx, issueID, fullURL)
+		if err != nil {
+			return fmt.Errorf("failed to link GitHub PR: %w", err)
+		}
 	}
 
 	// Format output

--- a/cmd/linear/commands/issue/update.go
+++ b/cmd/linear/commands/issue/update.go
@@ -68,6 +68,12 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 	ctx := cmd.Context()
 	res := resolver.New(client)
 
+	trash, _ := cmd.Flags().GetBool("trash")
+	untrash, _ := cmd.Flags().GetBool("untrash")
+	if trash && untrash {
+		return fmt.Errorf("--trash and --untrash are mutually exclusive")
+	}
+
 	// Resolve issue ID (converts identifier like ENG-123 to UUID)
 	resolvedIssueID, err := res.ResolveIssue(ctx, issueID)
 	if err != nil {
@@ -315,11 +321,11 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 		updated = true
 	}
 
-	if trash, _ := cmd.Flags().GetBool("trash"); trash {
+	if trash {
 		t := true
 		input.Trashed = &t
 		updated = true
-	} else if untrash, _ := cmd.Flags().GetBool("untrash"); untrash {
+	} else if untrash {
 		f := false
 		input.Trashed = &f
 		updated = true

--- a/cmd/linear/main.go
+++ b/cmd/linear/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"os"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/njayp/ophis"
 
 	"github.com/chainguard-sandbox/go-linear/v2/cmd/linear/commands"
@@ -26,13 +27,9 @@ import (
 func main() {
 	rootCmd := commands.NewRootCommand()
 
-	// Add ophis MCP integration
-	// This single line exposes the entire CLI as an MCP server!
-	// Ophis recursively walks the Cobra command tree and generates:
-	// - JSON schemas from command flags
-	// - MCP tool definitions
-	// - Tool execution by spawning CLI subprocesses
-	rootCmd.AddCommand(ophis.Command(nil))
+	rootCmd.AddCommand(ophis.Command(&ophis.Config{
+		Transport: &fixFlagsTransport{inner: &mcp.StdioTransport{}},
+	}))
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/linear/mcp_transport.go
+++ b/cmd/linear/mcp_transport.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// fixFlagsTransport wraps an mcp.Transport to normalize double-encoded flags.
+//
+// Some MCP clients (e.g. Claude Code) intermittently JSON-encode the
+// `arguments.flags` value twice, sending a string where the schema expects an
+// object. This transport intercepts tools/call requests before schema validation
+// and decodes the inner string back into an object.
+type fixFlagsTransport struct {
+	inner mcp.Transport
+}
+
+func (t *fixFlagsTransport) Connect(ctx context.Context) (mcp.Connection, error) {
+	conn, err := t.inner.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &fixFlagsConn{delegate: conn}, nil
+}
+
+type fixFlagsConn struct {
+	delegate mcp.Connection
+}
+
+func (c *fixFlagsConn) SessionID() string                          { return c.delegate.SessionID() }
+func (c *fixFlagsConn) Write(ctx context.Context, msg jsonrpc.Message) error {
+	return c.delegate.Write(ctx, msg)
+}
+func (c *fixFlagsConn) Close() error { return c.delegate.Close() }
+
+func (c *fixFlagsConn) Read(ctx context.Context) (jsonrpc.Message, error) {
+	msg, err := c.delegate.Read(ctx)
+	if err != nil {
+		return msg, err
+	}
+
+	req, ok := msg.(*jsonrpc.Request)
+	if !ok || req.Method != "tools/call" {
+		return msg, nil
+	}
+
+	fixed, err := fixDoubleEncodedFlags(req.Params)
+	if err != nil || fixed == nil {
+		return msg, nil
+	}
+	req.Params = fixed
+	return req, nil
+}
+
+// fixDoubleEncodedFlags detects and fixes double-encoded flags in tools/call params.
+// Returns nil if no fix was needed, or the corrected params if a fix was applied.
+func fixDoubleEncodedFlags(raw json.RawMessage) (json.RawMessage, error) {
+	var params struct {
+		Name      string                     `json:"name"`
+		Arguments map[string]json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, err
+	}
+
+	flagsRaw, ok := params.Arguments["flags"]
+	if !ok {
+		return nil, nil
+	}
+
+	// Check if flags is a JSON string (double-encoded)
+	var flagsStr string
+	if err := json.Unmarshal(flagsRaw, &flagsStr); err != nil {
+		return nil, nil // flags is already an object, no fix needed
+	}
+
+	// Decode the inner JSON string into an object
+	var flagsObj json.RawMessage
+	if err := json.Unmarshal([]byte(flagsStr), &flagsObj); err != nil {
+		return nil, nil // inner value isn't valid JSON, leave it alone
+	}
+
+	params.Arguments["flags"] = flagsObj
+	return json.Marshal(params)
+}

--- a/cmd/linear/mcp_transport.go
+++ b/cmd/linear/mcp_transport.go
@@ -30,7 +30,7 @@ type fixFlagsConn struct {
 	delegate mcp.Connection
 }
 
-func (c *fixFlagsConn) SessionID() string                          { return c.delegate.SessionID() }
+func (c *fixFlagsConn) SessionID() string { return c.delegate.SessionID() }
 func (c *fixFlagsConn) Write(ctx context.Context, msg jsonrpc.Message) error {
 	return c.delegate.Write(ctx, msg)
 }
@@ -47,8 +47,8 @@ func (c *fixFlagsConn) Read(ctx context.Context) (jsonrpc.Message, error) {
 		return msg, nil
 	}
 
-	fixed, err := fixDoubleEncodedFlags(req.Params)
-	if err != nil || fixed == nil {
+	fixed, _ := fixDoubleEncodedFlags(req.Params)
+	if fixed == nil {
 		return msg, nil
 	}
 	req.Params = fixed
@@ -71,18 +71,36 @@ func fixDoubleEncodedFlags(raw json.RawMessage) (json.RawMessage, error) {
 		return nil, nil
 	}
 
-	// Check if flags is a JSON string (double-encoded)
-	var flagsStr string
-	if err := json.Unmarshal(flagsRaw, &flagsStr); err != nil {
-		return nil, nil // flags is already an object, no fix needed
+	// If flags is not a JSON string, it's already an object — no fix needed.
+	flagsStr, ok := asJSONString(flagsRaw)
+	if !ok {
+		return nil, nil
 	}
 
-	// Decode the inner JSON string into an object
-	var flagsObj json.RawMessage
-	if err := json.Unmarshal([]byte(flagsStr), &flagsObj); err != nil {
-		return nil, nil // inner value isn't valid JSON, leave it alone
+	// Decode the inner JSON string into an object; leave it alone if invalid.
+	flagsObj, ok := asJSONObject([]byte(flagsStr))
+	if !ok {
+		return nil, nil
 	}
 
 	params.Arguments["flags"] = flagsObj
 	return json.Marshal(params)
+}
+
+// asJSONString returns the string value if raw is a JSON string, else ("", false).
+func asJSONString(raw json.RawMessage) (string, bool) {
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return "", false
+	}
+	return s, true
+}
+
+// asJSONObject returns raw as a RawMessage if it is valid JSON object/array, else (nil, false).
+func asJSONObject(data []byte) (json.RawMessage, bool) {
+	var obj json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, false
+	}
+	return obj, true
 }

--- a/cmd/linear/mcp_transport_test.go
+++ b/cmd/linear/mcp_transport_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFixDoubleEncodedFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantNil bool // true = no fix needed
+		wantOut string
+	}{
+		{
+			name:    "already an object - no fix",
+			input:   `{"name":"go-linear_issue_update","arguments":{"flags":{"state":"Done"}}}`,
+			wantNil: true,
+		},
+		{
+			name:    "double-encoded flags - fixed",
+			input:   `{"name":"go-linear_issue_update","arguments":{"flags":"{\"state\":\"Done\"}"}}`,
+			wantOut: `{"name":"go-linear_issue_update","arguments":{"flags":{"state":"Done"}}}`,
+		},
+		{
+			name:    "no flags key - no fix",
+			input:   `{"name":"go-linear_issue_list","arguments":{}}`,
+			wantNil: true,
+		},
+		{
+			name:    "double-encoded with multiple fields",
+			input:   `{"name":"go-linear_issue_update","arguments":{"flags":"{\"issue\":\"ENG-1\",\"body\":\"test\"}"}}`,
+			wantOut: `{"name":"go-linear_issue_update","arguments":{"flags":{"issue":"ENG-1","body":"test"}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := fixDoubleEncodedFlags(json.RawMessage(tt.input))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNil {
+				if result != nil {
+					t.Errorf("expected nil, got %s", result)
+				}
+				return
+			}
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			// Normalize by round-tripping through map to avoid key-order differences
+			var got, want map[string]any
+			if err := json.Unmarshal(result, &got); err != nil {
+				t.Fatalf("result is invalid JSON: %v", err)
+			}
+			if err := json.Unmarshal([]byte(tt.wantOut), &want); err != nil {
+				t.Fatalf("wantOut is invalid JSON: %v", err)
+			}
+			gotB, _ := json.Marshal(got)
+			wantB, _ := json.Marshal(want)
+			if string(gotB) != string(wantB) {
+				t.Errorf("got %s, want %s", gotB, wantB)
+			}
+		})
+	}
+}

--- a/cmd/linear/mcp_transport_test.go
+++ b/cmd/linear/mcp_transport_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 )
@@ -59,7 +60,7 @@ func TestFixDoubleEncodedFlags(t *testing.T) {
 			}
 			gotB, _ := json.Marshal(got)
 			wantB, _ := json.Marshal(want)
-			if string(gotB) != string(wantB) {
+			if !bytes.Equal(gotB, wantB) {
 				t.Errorf("got %s, want %s", gotB, wantB)
 			}
 		})

--- a/internal/dateparser/parser.go
+++ b/internal/dateparser/parser.go
@@ -88,6 +88,61 @@ func (p Parser) Parse(input string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("invalid date format: %s (supported: ISO8601, 'today', 'yesterday', '7d', '2w', '3m')", input)
 }
 
+// ParseFuture parses a date string treating durations as future offsets.
+//
+// For duration formats ("7d", "2w", "3m"), the duration is added to now.
+// Use this for snooze/deadline inputs where "3d" means "3 days from now".
+// Unlike Parse, "today" and "yesterday" are rejected as non-future dates.
+func (p Parser) ParseFuture(input string) (time.Time, error) {
+	if input == "" {
+		return time.Time{}, fmt.Errorf("empty date string")
+	}
+
+	if t, err := time.Parse("2006-01-02", input); err == nil {
+		return t.UTC(), nil
+	}
+
+	if t, err := time.Parse(time.RFC3339, input); err == nil {
+		return t.UTC(), nil
+	}
+
+	now := time.Now().UTC()
+	switch strings.ToLower(input) {
+	case "today":
+		return time.Time{}, fmt.Errorf("'today' is ambiguous as a future date; use 'tomorrow' or a duration like '1d'")
+	case "yesterday":
+		return time.Time{}, fmt.Errorf("'yesterday' is not a future date")
+	case "tomorrow":
+		tomorrow := now.Add(24 * time.Hour)
+		return time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 0, 0, 0, 0, time.UTC), nil
+	}
+
+	if matches := durationRegex.FindStringSubmatch(input); matches != nil {
+		amount, err := strconv.Atoi(matches[1])
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid duration amount: %s", matches[1])
+		}
+
+		unit := matches[2]
+		var duration time.Duration
+
+		switch unit {
+		case "d":
+			duration = time.Duration(amount) * 24 * time.Hour
+		case "w":
+			duration = time.Duration(amount) * 7 * 24 * time.Hour
+		case "m":
+			duration = time.Duration(amount) * 30 * 24 * time.Hour
+		default:
+			return time.Time{}, fmt.Errorf("invalid duration unit: %s", unit)
+		}
+
+		return now.Add(duration), nil
+	}
+
+	return time.Time{}, fmt.Errorf("invalid date format: %s (supported: ISO8601, 'tomorrow', '3d', '2w', '3m')", input)
+}
+
 // MustParse parses a date string and panics on error.
 // Useful for testing and initialization.
 func (p Parser) MustParse(input string) time.Time {

--- a/internal/dateparser/parser.go
+++ b/internal/dateparser/parser.go
@@ -137,7 +137,8 @@ func (p Parser) ParseFuture(input string) (time.Time, error) {
 			return time.Time{}, fmt.Errorf("invalid duration unit: %s", unit)
 		}
 
-		return now.Add(duration), nil
+		result := now.Add(duration)
+		return time.Date(result.Year(), result.Month(), result.Day(), 0, 0, 0, 0, time.UTC), nil
 	}
 
 	return time.Time{}, fmt.Errorf("invalid date format: %s (supported: ISO8601, 'tomorrow', '3d', '2w', '3m')", input)

--- a/internal/dateparser/parser_test.go
+++ b/internal/dateparser/parser_test.go
@@ -142,6 +142,131 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestParseFuture(t *testing.T) {
+	p := New()
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+		check   func(t *testing.T, result time.Time)
+	}{
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "ISO 8601 date",
+			input:   "2099-12-10",
+			wantErr: false,
+			check: func(t *testing.T, result time.Time) {
+				if result.Year() != 2099 || result.Month() != 12 || result.Day() != 10 {
+					t.Errorf("ParseFuture() = %v, want 2099-12-10", result)
+				}
+			},
+		},
+		{
+			name:    "RFC3339",
+			input:   "2099-12-10T15:04:05Z",
+			wantErr: false,
+			check: func(t *testing.T, result time.Time) {
+				if result.Year() != 2099 || result.Month() != 12 || result.Day() != 10 {
+					t.Errorf("ParseFuture() = %v, want 2099-12-10", result)
+				}
+			},
+		},
+		{
+			name:    "tomorrow",
+			input:   "tomorrow",
+			wantErr: false,
+			check: func(t *testing.T, result time.Time) {
+				tomorrow := now.Add(24 * time.Hour)
+				if result.Year() != tomorrow.Year() || result.Month() != tomorrow.Month() || result.Day() != tomorrow.Day() {
+					t.Errorf("ParseFuture('tomorrow') = %v, want tomorrow", result)
+				}
+				if result.Hour() != 0 || result.Minute() != 0 || result.Second() != 0 {
+					t.Errorf("ParseFuture('tomorrow') time = %v, want 00:00:00", result)
+				}
+			},
+		},
+		{
+			name:    "today rejected",
+			input:   "today",
+			wantErr: true,
+		},
+		{
+			name:    "yesterday rejected",
+			input:   "yesterday",
+			wantErr: true,
+		},
+		{
+			name:    "7 days forward",
+			input:   "7d",
+			wantErr: false,
+			check: func(t *testing.T, result time.Time) {
+				sevenDaysAhead := now.Add(7 * 24 * time.Hour)
+				if result.Year() != sevenDaysAhead.Year() || result.Month() != sevenDaysAhead.Month() || result.Day() != sevenDaysAhead.Day() {
+					t.Errorf("ParseFuture('7d') = %v, want 7 days ahead", result)
+				}
+				if result.Hour() != 0 || result.Minute() != 0 || result.Second() != 0 {
+					t.Errorf("ParseFuture('7d') time = %v, want 00:00:00", result)
+				}
+			},
+		},
+		{
+			name:    "2 weeks forward",
+			input:   "2w",
+			wantErr: false,
+			check: func(t *testing.T, result time.Time) {
+				twoWeeksAhead := now.Add(14 * 24 * time.Hour)
+				if result.Year() != twoWeeksAhead.Year() || result.Month() != twoWeeksAhead.Month() || result.Day() != twoWeeksAhead.Day() {
+					t.Errorf("ParseFuture('2w') = %v, want 2 weeks ahead", result)
+				}
+			},
+		},
+		{
+			name:    "3 months forward",
+			input:   "3m",
+			wantErr: false,
+			check: func(t *testing.T, result time.Time) {
+				threeMonthsAhead := now.Add(90 * 24 * time.Hour)
+				diff := threeMonthsAhead.Sub(result)
+				if diff < 0 {
+					diff = -diff
+				}
+				if diff > 2*24*time.Hour {
+					t.Errorf("ParseFuture('3m') = %v, want approximately 3 months ahead", result)
+				}
+			},
+		},
+		{
+			name:    "none rejected",
+			input:   "none",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format",
+			input:   "invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := p.ParseFuture(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseFuture() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && tt.check != nil {
+				tt.check(t, result)
+			}
+		})
+	}
+}
+
 func TestMustParse(t *testing.T) {
 	p := New()
 

--- a/internal/graphql/client.go
+++ b/internal/graphql/client.go
@@ -33,6 +33,7 @@ type LinearGraphQLClient interface {
 	ListSubInitiatives(ctx context.Context, id string, first *int64, after *string, interceptors ...clientv2.RequestInterceptor) (*ListSubInitiatives, error)
 	GetIssueSuggestionsForIssue(ctx context.Context, issueID string, first *int64, after *string, interceptors ...clientv2.RequestInterceptor) (*GetIssueSuggestionsForIssue, error)
 	GetIssue(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*GetIssue, error)
+	GetIssueSubscribers(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*GetIssueSubscribers, error)
 	ListIssues(ctx context.Context, first *int64, after *string, interceptors ...clientv2.RequestInterceptor) (*ListIssues, error)
 	ListIssuesFiltered(ctx context.Context, first *int64, after *string, filter *IssueFilter, interceptors ...clientv2.RequestInterceptor) (*ListIssuesFiltered, error)
 	GetLabel(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*GetLabel, error)
@@ -3067,6 +3068,39 @@ func (t *GetIssue_Issue) GetURL() string {
 		t = &GetIssue_Issue{}
 	}
 	return t.URL
+}
+
+type GetIssueSubscribers_Issue_Subscribers_Nodes struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetIssueSubscribers_Issue_Subscribers_Nodes) GetID() string {
+	if t == nil {
+		t = &GetIssueSubscribers_Issue_Subscribers_Nodes{}
+	}
+	return t.ID
+}
+
+type GetIssueSubscribers_Issue_Subscribers struct {
+	Nodes []*GetIssueSubscribers_Issue_Subscribers_Nodes "json:\"nodes\" graphql:\"nodes\""
+}
+
+func (t *GetIssueSubscribers_Issue_Subscribers) GetNodes() []*GetIssueSubscribers_Issue_Subscribers_Nodes {
+	if t == nil {
+		t = &GetIssueSubscribers_Issue_Subscribers{}
+	}
+	return t.Nodes
+}
+
+type GetIssueSubscribers_Issue struct {
+	Subscribers GetIssueSubscribers_Issue_Subscribers "json:\"subscribers\" graphql:\"subscribers\""
+}
+
+func (t *GetIssueSubscribers_Issue) GetSubscribers() *GetIssueSubscribers_Issue_Subscribers {
+	if t == nil {
+		t = &GetIssueSubscribers_Issue{}
+	}
+	return &t.Subscribers
 }
 
 type ListIssues_Issues_Nodes_State struct {
@@ -9320,6 +9354,17 @@ func (t *GetIssue) GetIssue() *GetIssue_Issue {
 	return &t.Issue
 }
 
+type GetIssueSubscribers struct {
+	Issue GetIssueSubscribers_Issue "json:\"issue\" graphql:\"issue\""
+}
+
+func (t *GetIssueSubscribers) GetIssue() *GetIssueSubscribers_Issue {
+	if t == nil {
+		t = &GetIssueSubscribers{}
+	}
+	return &t.Issue
+}
+
 type ListIssues struct {
 	Issues ListIssues_Issues "json:\"issues\" graphql:\"issues\""
 }
@@ -11312,6 +11357,34 @@ func (c *Client) GetIssue(ctx context.Context, id string, interceptors ...client
 
 	var res GetIssue
 	if err := c.Client.Post(ctx, "GetIssue", GetIssueDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const GetIssueSubscribersDocument = `query GetIssueSubscribers ($id: String!) {
+	issue(id: $id) {
+		subscribers(first: 250) {
+			nodes {
+				id
+			}
+		}
+	}
+}
+`
+
+func (c *Client) GetIssueSubscribers(ctx context.Context, id string, interceptors ...clientv2.RequestInterceptor) (*GetIssueSubscribers, error) {
+	vars := map[string]any{
+		"id": id,
+	}
+
+	var res GetIssueSubscribers
+	if err := c.Client.Post(ctx, "GetIssueSubscribers", GetIssueSubscribersDocument, &res, vars, interceptors...); err != nil {
 		if c.Client.ParseDataWhenErrors {
 			return &res, err
 		}
@@ -14362,6 +14435,7 @@ var DocumentOperationNames = map[string]string{
 	ListSubInitiativesDocument:             "ListSubInitiatives",
 	GetIssueSuggestionsForIssueDocument:    "GetIssueSuggestionsForIssue",
 	GetIssueDocument:                       "GetIssue",
+	GetIssueSubscribersDocument:            "GetIssueSubscribers",
 	ListIssuesDocument:                     "ListIssues",
 	ListIssuesFilteredDocument:             "ListIssuesFiltered",
 	GetLabelDocument:                       "GetLabel",

--- a/pkg/linear/client_issues.go
+++ b/pkg/linear/client_issues.go
@@ -1,8 +1,12 @@
 package linear
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
 )
@@ -591,4 +595,77 @@ func (c *Client) IssueSuggestions(ctx context.Context, issueID string, first *in
 		return nil, wrapGraphQLError("issue suggestions query", err)
 	}
 	return &resp.Issue, nil
+}
+
+// IssueSubscriberIDs fetches the current subscriber UUIDs for an issue.
+func (c *Client) IssueSubscriberIDs(ctx context.Context, issueID string) ([]string, error) {
+	const query = `query IssueSubscribers($id: String!) {
+		issue(id: $id) {
+			subscribers { nodes { id } }
+		}
+	}`
+
+	reqBody := map[string]any{
+		"query":         query,
+		"operationName": "IssueSubscribers",
+		"variables":     map[string]any{"id": issueID},
+	}
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.config.BaseURL, bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", c.config.UserAgent)
+
+	authValue, err := c.credentialProvider.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get credential: %w", err)
+	}
+	authValue = normalizeAuthHeader(authValue)
+	req.Header.Set("Authorization", authValue)
+
+	resp, err := c.config.HTTPClient.Do(req) // #nosec G704
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("nil response from HTTP client")
+	}
+	defer resp.Body.Close()
+
+	const maxResponseSize = 10 * 1024 * 1024
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Data struct {
+			Issue struct {
+				Subscribers struct {
+					Nodes []struct {
+						ID string `json:"id"`
+					} `json:"nodes"`
+				} `json:"subscribers"`
+			} `json:"issue"`
+		} `json:"data"`
+		Errors []map[string]any `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+	if len(result.Errors) > 0 {
+		return nil, fmt.Errorf("GraphQL error: %v", result.Errors[0])
+	}
+
+	ids := make([]string, 0, len(result.Data.Issue.Subscribers.Nodes))
+	for _, n := range result.Data.Issue.Subscribers.Nodes {
+		ids = append(ids, n.ID)
+	}
+	return ids, nil
 }

--- a/pkg/linear/client_issues.go
+++ b/pkg/linear/client_issues.go
@@ -1,12 +1,8 @@
 package linear
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 
 	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
 )
@@ -599,73 +595,14 @@ func (c *Client) IssueSuggestions(ctx context.Context, issueID string, first *in
 
 // IssueSubscriberIDs fetches the current subscriber UUIDs for an issue.
 func (c *Client) IssueSubscriberIDs(ctx context.Context, issueID string) ([]string, error) {
-	const query = `query IssueSubscribers($id: String!) {
-		issue(id: $id) {
-			subscribers { nodes { id } }
-		}
-	}`
-
-	reqBody := map[string]any{
-		"query":         query,
-		"operationName": "IssueSubscribers",
-		"variables":     map[string]any{"id": issueID},
-	}
-	jsonData, err := json.Marshal(reqBody)
+	resp, err := c.gqlClient.GetIssueSubscribers(ctx, issueID)
 	if err != nil {
-		return nil, err
+		return nil, wrapGraphQLError("issue subscribers query", err)
 	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", c.config.BaseURL, bytes.NewReader(jsonData))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", c.config.UserAgent)
-
-	authValue, err := c.credentialProvider.Get(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get credential: %w", err)
-	}
-	authValue = normalizeAuthHeader(authValue)
-	req.Header.Set("Authorization", authValue)
-
-	resp, err := c.config.HTTPClient.Do(req) // #nosec G704
-	if err != nil {
-		return nil, err
-	}
-	if resp == nil {
-		return nil, fmt.Errorf("nil response from HTTP client")
-	}
-	defer resp.Body.Close()
-
-	const maxResponseSize = 10 * 1024 * 1024
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
-	if err != nil {
-		return nil, err
-	}
-
-	var result struct {
-		Data struct {
-			Issue struct {
-				Subscribers struct {
-					Nodes []struct {
-						ID string `json:"id"`
-					} `json:"nodes"`
-				} `json:"subscribers"`
-			} `json:"issue"`
-		} `json:"data"`
-		Errors []map[string]any `json:"errors"`
-	}
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, err
-	}
-	if len(result.Errors) > 0 {
-		return nil, fmt.Errorf("GraphQL error: %v", result.Errors[0])
-	}
-
-	ids := make([]string, 0, len(result.Data.Issue.Subscribers.Nodes))
-	for _, n := range result.Data.Issue.Subscribers.Nodes {
-		ids = append(ids, n.ID)
+	nodes := resp.Issue.Subscribers.GetNodes()
+	ids := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		ids = append(ids, n.GetID())
 	}
 	return ids, nil
 }

--- a/pkg/linear/issue_update_nullable.go
+++ b/pkg/linear/issue_update_nullable.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	intgraphql "github.com/chainguard-sandbox/go-linear/v2/internal/graphql"
 )
@@ -127,6 +128,9 @@ type IssueUpdateNullableInput struct {
 	StateID         *string
 	Priority        *int64
 	Estimate        *int64
+	TeamID          *string
+	SubscriberIDs   []string
+	Trashed         *bool
 	AddedLabelIds   []string
 	RemovedLabelIds []string
 
@@ -137,6 +141,7 @@ type IssueUpdateNullableInput struct {
 	ProjectID          Nullable[string]
 	DueDate            Nullable[string]
 	ProjectMilestoneID Nullable[string]
+	SnoozedUntilAt     Nullable[time.Time]
 }
 
 // ToMap converts to map for JSON encoding with explicit null support.
@@ -166,6 +171,15 @@ func (i *IssueUpdateNullableInput) ToMap() map[string]any {
 	}
 	if i.Estimate != nil {
 		m["estimate"] = *i.Estimate
+	}
+	if i.TeamID != nil {
+		m["teamId"] = *i.TeamID
+	}
+	if len(i.SubscriberIDs) > 0 {
+		m["subscriberIds"] = i.SubscriberIDs
+	}
+	if i.Trashed != nil {
+		m["trashed"] = *i.Trashed
 	}
 	if len(i.AddedLabelIds) > 0 {
 		m["addedLabelIds"] = i.AddedLabelIds
@@ -221,6 +235,16 @@ func (i *IssueUpdateNullableInput) ToMap() map[string]any {
 				m["projectMilestoneId"] = nil // Explicit null
 			} else {
 				m["projectMilestoneId"] = *val
+			}
+		}
+	}
+
+	if i.SnoozedUntilAt.IsSet() {
+		if val, ok := i.SnoozedUntilAt.Get(); ok {
+			if val == nil {
+				m["snoozedUntilAt"] = nil // Explicit null clears the snooze
+			} else {
+				m["snoozedUntilAt"] = val.Format("2006-01-02T15:04:05.000Z")
 			}
 		}
 	}

--- a/pkg/linear/issue_update_nullable.go
+++ b/pkg/linear/issue_update_nullable.go
@@ -126,6 +126,7 @@ type IssueUpdateNullableInput struct {
 	Description     *string
 	StateID         *string
 	Priority        *int64
+	Estimate        *int64
 	AddedLabelIds   []string
 	RemovedLabelIds []string
 
@@ -162,6 +163,9 @@ func (i *IssueUpdateNullableInput) ToMap() map[string]any {
 	}
 	if i.Priority != nil {
 		m["priority"] = *i.Priority
+	}
+	if i.Estimate != nil {
+		m["estimate"] = *i.Estimate
 	}
 	if len(i.AddedLabelIds) > 0 {
 		m["addedLabelIds"] = i.AddedLabelIds

--- a/pkg/linear/issue_update_nullable.go
+++ b/pkg/linear/issue_update_nullable.go
@@ -127,7 +127,7 @@ type IssueUpdateNullableInput struct {
 	Description     *string
 	StateID         *string
 	Priority        *int64
-	Estimate        *int64
+	Estimate        Nullable[int64]
 	TeamID          *string
 	SubscriberIDs   []string
 	Trashed         *bool
@@ -169,8 +169,14 @@ func (i *IssueUpdateNullableInput) ToMap() map[string]any {
 	if i.Priority != nil {
 		m["priority"] = *i.Priority
 	}
-	if i.Estimate != nil {
-		m["estimate"] = *i.Estimate
+	if i.Estimate.IsSet() {
+		if val, ok := i.Estimate.Get(); ok {
+			if val == nil {
+				m["estimate"] = nil
+			} else {
+				m["estimate"] = *val
+			}
+		}
 	}
 	if i.TeamID != nil {
 		m["teamId"] = *i.TeamID

--- a/queries/issues.graphql
+++ b/queries/issues.graphql
@@ -39,6 +39,16 @@ query GetIssue($id: String!) {
   }
 }
 
+query GetIssueSubscribers($id: String!) {
+  issue(id: $id) {
+    subscribers(first: 250) {
+      nodes {
+        id
+      }
+    }
+  }
+}
+
 query ListIssues($first: Int, $after: String) {
   issues(first: $first, after: $after) {
     nodes {


### PR DESCRIPTION
Adds `--estimate` and other flags to `issue update`, matching the flag already present in `issue create`
Wires estimate through both the standard `IssueUpdateInput` path and the nullable `IssueUpdateNullableInput` path
The Linear GraphQL `issueUpdate` mutation already accepts `estimate`; this just exposes it in the CLI
Closes https://github.com/chainguard-sandbox/go-linear/issues/71