### PR TITLE
test: add property and fuzz tests for Nullable, dateparser, and fieldfilter

### DIFF
--- a/internal/dateparser/parser_property_test.go
+++ b/internal/dateparser/parser_property_test.go
@@ -1,0 +1,104 @@
+package dateparser
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// Property: all "Nd" results are in the past relative to when the test started.
+func TestParse_RelativeDatesArePast(t *testing.T) {
+	p := New()
+	before := time.Now().UTC()
+	for _, n := range []int{1, 2, 7, 14, 30, 90, 365} {
+		input := fmt.Sprintf("%dd", n)
+		result, err := p.Parse(input)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", input, err)
+		}
+		if !result.Before(before) {
+			t.Errorf("Parse(%q) = %v is not before now (%v)", input, result, before)
+		}
+	}
+}
+
+// Property: larger N in "Nd" → earlier timestamp (strictly monotonic).
+func TestParse_RelativeDay_Monotonic(t *testing.T) {
+	p := New()
+	pairs := [][2]int{{1, 2}, {2, 7}, {7, 14}, {14, 30}, {30, 90}, {90, 365}}
+	for _, pair := range pairs {
+		smaller, larger := pair[0], pair[1]
+		t1, _ := p.Parse(fmt.Sprintf("%dd", smaller))
+		t2, _ := p.Parse(fmt.Sprintf("%dd", larger))
+		if !t1.After(t2) {
+			t.Errorf("%dd (%v) should be after %dd (%v)", smaller, t1, larger, t2)
+		}
+	}
+}
+
+// Property: 1d < 1w < 1m in terms of distance from now
+// (smaller offset = more recent = larger timestamp).
+func TestParse_UnitOrdering(t *testing.T) {
+	p := New()
+	d1, _ := p.Parse("1d")
+	w1, _ := p.Parse("1w")
+	m1, _ := p.Parse("1m")
+	if !d1.After(w1) {
+		t.Errorf("1d (%v) should be after 1w (%v)", d1, w1)
+	}
+	if !w1.After(m1) {
+		t.Errorf("1w (%v) should be after 1m (%v)", w1, m1)
+	}
+}
+
+// Property: yesterday < today < tomorrow.
+func TestParse_NamedDateOrdering(t *testing.T) {
+	p := New()
+	yesterday, _ := p.Parse("yesterday")
+	today, _ := p.Parse("today")
+	tomorrow, _ := p.Parse("tomorrow")
+	if !today.After(yesterday) {
+		t.Errorf("today (%v) should be after yesterday (%v)", today, yesterday)
+	}
+	if !tomorrow.After(today) {
+		t.Errorf("tomorrow (%v) should be after today (%v)", tomorrow, today)
+	}
+}
+
+// Property: all relative/named results are UTC with zero time component.
+func TestParse_ResultsAreUTCMidnight(t *testing.T) {
+	p := New()
+	inputs := []string{"today", "yesterday", "tomorrow", "1d", "7d", "2w", "3m"}
+	for _, input := range inputs {
+		result, err := p.Parse(input)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", input, err)
+		}
+		if result.Location() != time.UTC {
+			t.Errorf("Parse(%q) location = %v, want UTC", input, result.Location())
+		}
+		if h, m, s, ns := result.Hour(), result.Minute(), result.Second(), result.Nanosecond(); h != 0 || m != 0 || s != 0 || ns != 0 {
+			t.Errorf("Parse(%q) = %v, want midnight UTC", input, result)
+		}
+	}
+}
+
+// Fuzz: Parse never panics; on success result is always UTC.
+func FuzzParse_NoPanic(f *testing.F) {
+	f.Add("7d")
+	f.Add("today")
+	f.Add("2025-12-10")
+	f.Add("2025-12-10T15:04:05Z")
+	f.Add("")
+	f.Add("invalid")
+	f.Add("0d")
+	f.Add("999m")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		p := New()
+		result, err := p.Parse(s)
+		if err == nil && result.Location() != time.UTC {
+			t.Errorf("Parse(%q) succeeded but result is not UTC: %v", s, result)
+		}
+	})
+}

--- a/internal/dateparser/parser_property_test.go
+++ b/internal/dateparser/parser_property_test.go
@@ -22,14 +22,26 @@ func TestParse_RelativeDatesArePast(t *testing.T) {
 	}
 }
 
+// mustParse parses input, failing the test if Parse returns an error for an
+// input the caller assumes is valid. Swallowing the error would otherwise
+// surface as a misleading ordering assertion on a zero-value time.
+func mustParse(t *testing.T, p Parser, input string) time.Time {
+	t.Helper()
+	result, err := p.Parse(input)
+	if err != nil {
+		t.Fatalf("Parse(%q): unexpected error: %v", input, err)
+	}
+	return result
+}
+
 // Property: larger N in "Nd" → earlier timestamp (strictly monotonic).
 func TestParse_RelativeDay_Monotonic(t *testing.T) {
 	p := New()
 	pairs := [][2]int{{1, 2}, {2, 7}, {7, 14}, {14, 30}, {30, 90}, {90, 365}}
 	for _, pair := range pairs {
 		smaller, larger := pair[0], pair[1]
-		t1, _ := p.Parse(fmt.Sprintf("%dd", smaller))
-		t2, _ := p.Parse(fmt.Sprintf("%dd", larger))
+		t1 := mustParse(t, p, fmt.Sprintf("%dd", smaller))
+		t2 := mustParse(t, p, fmt.Sprintf("%dd", larger))
 		if !t1.After(t2) {
 			t.Errorf("%dd (%v) should be after %dd (%v)", smaller, t1, larger, t2)
 		}
@@ -40,9 +52,9 @@ func TestParse_RelativeDay_Monotonic(t *testing.T) {
 // (smaller offset = more recent = larger timestamp).
 func TestParse_UnitOrdering(t *testing.T) {
 	p := New()
-	d1, _ := p.Parse("1d")
-	w1, _ := p.Parse("1w")
-	m1, _ := p.Parse("1m")
+	d1 := mustParse(t, p, "1d")
+	w1 := mustParse(t, p, "1w")
+	m1 := mustParse(t, p, "1m")
 	if !d1.After(w1) {
 		t.Errorf("1d (%v) should be after 1w (%v)", d1, w1)
 	}
@@ -54,9 +66,9 @@ func TestParse_UnitOrdering(t *testing.T) {
 // Property: yesterday < today < tomorrow.
 func TestParse_NamedDateOrdering(t *testing.T) {
 	p := New()
-	yesterday, _ := p.Parse("yesterday")
-	today, _ := p.Parse("today")
-	tomorrow, _ := p.Parse("tomorrow")
+	yesterday := mustParse(t, p, "yesterday")
+	today := mustParse(t, p, "today")
+	tomorrow := mustParse(t, p, "tomorrow")
 	if !today.After(yesterday) {
 		t.Errorf("today (%v) should be after yesterday (%v)", today, yesterday)
 	}

--- a/internal/fieldfilter/selector_property_test.go
+++ b/internal/fieldfilter/selector_property_test.go
@@ -6,6 +6,97 @@ import (
 	"testing"
 )
 
+// fieldError.Error() is exercised when an error is returned and its message is read.
+func TestNew_ErrorMessage(t *testing.T) {
+	_, err := New("id,,title", nil)
+	if err == nil {
+		t.Fatal("expected error for empty field in spec")
+	}
+	if err.Error() == "" {
+		t.Error("error message should not be empty")
+	}
+}
+
+// New("defaults", nil) with no command defaults resolves to an empty field list
+// and should return a nil selector (no filtering).
+func TestNew_DefaultsNoCommandDefaults(t *testing.T) {
+	fs, err := New("defaults", nil)
+	if err != nil {
+		t.Fatalf("New(\"defaults\", nil): %v", err)
+	}
+	if fs != nil {
+		t.Error("expected nil selector when defaults spec has no configured defaults")
+	}
+}
+
+// NewForList returns nil when New returns nil (no filtering requested).
+func TestNewForList_NilPassthrough(t *testing.T) {
+	fs, err := NewForList("none", nil)
+	if err != nil {
+		t.Fatalf("NewForList(\"none\", nil): %v", err)
+	}
+	if fs != nil {
+		t.Error("expected nil selector for 'none' spec")
+	}
+}
+
+// NewForList propagates errors from New (e.g. empty field in spec).
+func TestNewForList_PropagatesError(t *testing.T) {
+	_, err := NewForList("id,,title", nil)
+	if err == nil {
+		t.Error("expected error for empty field in spec")
+	}
+}
+
+// NewForList preserves pagination wrapper fields (nodes, pageInfo, totalCount)
+// while filtering inner object fields — exercises filterObject's preserveFields branch.
+func TestNewForList_PreservesWrapperFields(t *testing.T) {
+	fs, err := NewForList("id,title", nil)
+	if err != nil {
+		t.Fatalf("NewForList: %v", err)
+	}
+	input := `{"nodes":[{"id":"1","title":"T","extra":"e"}],"pageInfo":{"hasNextPage":false},"totalCount":1}`
+	out, err := fs.Filter([]byte(input))
+	if err != nil {
+		t.Fatalf("Filter: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(out, &obj); err != nil {
+		t.Fatalf("output not valid JSON: %v", err)
+	}
+	for _, key := range []string{"nodes", "pageInfo", "totalCount"} {
+		if _, ok := obj[key]; !ok {
+			t.Errorf("wrapper field %q missing from output", key)
+		}
+	}
+	nodes := obj["nodes"].([]any)
+	inner := nodes[0].(map[string]any)
+	if _, ok := inner["extra"]; ok {
+		t.Error("inner field 'extra' should have been filtered out")
+	}
+}
+
+// Filter returns an error on invalid JSON input.
+func TestFilter_InvalidJSON(t *testing.T) {
+	fs, _ := New("id", nil)
+	_, err := fs.Filter([]byte(`{invalid json`))
+	if err == nil {
+		t.Error("expected error for invalid JSON input")
+	}
+}
+
+// filterValue default branch: scalar values inside an array pass through unchanged.
+func TestFilter_ScalarArrayElements(t *testing.T) {
+	fs, _ := New("id", nil)
+	out, err := fs.Filter([]byte(`["a", "b", "c"]`))
+	if err != nil {
+		t.Fatalf("Filter: %v", err)
+	}
+	if !json.Valid(out) {
+		t.Errorf("output is not valid JSON: %s", out)
+	}
+}
+
 // Property: Filter is idempotent — applying the same spec twice equals applying it once.
 func TestFilter_Idempotent(t *testing.T) {
 	cases := []struct {

--- a/internal/fieldfilter/selector_property_test.go
+++ b/internal/fieldfilter/selector_property_test.go
@@ -1,0 +1,156 @@
+package fieldfilter
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Property: Filter is idempotent — applying the same spec twice equals applying it once.
+func TestFilter_Idempotent(t *testing.T) {
+	cases := []struct {
+		name  string
+		spec  string
+		input string
+	}{
+		{"simple", "id", `{"id":"123","title":"Test","priority":1}`},
+		{"multi", "id,title", `{"id":"1","title":"T","extra":"e"}`},
+		{"nested", "id,assignee.name", `{"id":"1","assignee":{"name":"Alice","email":"a@b.com"}}`},
+		{"array", "id,title", `[{"id":"1","title":"A","extra":"x"},{"id":"2","title":"B","extra":"y"}]`},
+		{"no match", "missing", `{"id":"1","title":"T"}`},
+		{"empty object", "id", `{}`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fs, err := New(c.spec, nil)
+			if err != nil {
+				t.Fatalf("New(%q): %v", c.spec, err)
+			}
+			once, err := fs.Filter([]byte(c.input))
+			if err != nil {
+				t.Fatalf("Filter() first pass: %v", err)
+			}
+			twice, err := fs.Filter(once)
+			if err != nil {
+				t.Fatalf("Filter() second pass: %v", err)
+			}
+			if !jsonEqual(once, twice) {
+				t.Errorf("Idempotent: first=%s second=%s", once, twice)
+			}
+		})
+	}
+}
+
+// Property: every key in the filtered output was requested in the spec
+// (directly or as the parent of a nested selector).
+func TestFilter_OutputIsSubset(t *testing.T) {
+	cases := []struct {
+		name  string
+		spec  string
+		input string
+	}{
+		{"simple subset", "id,title", `{"id":"1","title":"T","extra":"e","priority":1}`},
+		{"only id", "id", `{"id":"1","title":"T","extra":"e"}`},
+		{"nested parent key", "assignee.name", `{"id":"1","assignee":{"name":"Alice","email":"a@b.com"}}`},
+		{"nothing matches", "missing", `{"id":"1","title":"T"}`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fs, err := New(c.spec, nil)
+			if err != nil {
+				t.Fatalf("New(%q): %v", c.spec, err)
+			}
+			out, err := fs.Filter([]byte(c.input))
+			if err != nil {
+				t.Fatalf("Filter(): %v", err)
+			}
+
+			var obj map[string]any
+			if err := json.Unmarshal(out, &obj); err != nil {
+				t.Fatalf("output is not a valid JSON object: %v — output: %s", err, out)
+			}
+			for key := range obj {
+				if !keyInSpec(key, fs.fields) {
+					t.Errorf("output key %q was not requested in spec %q", key, c.spec)
+				}
+			}
+		})
+	}
+}
+
+// Property: output is always valid JSON, even when no fields match.
+func TestFilter_AlwaysValidJSON(t *testing.T) {
+	cases := []struct{ spec, input string }{
+		{"id", `{"id":"1","title":"T"}`},
+		{"missing", `{"id":"1","title":"T"}`},
+		{"id,title", `[{"id":"1"},{"id":"2"}]`},
+		{"x", `{}`},
+		{"x", `[]`},
+	}
+	for _, c := range cases {
+		fs, err := New(c.spec, nil)
+		if err != nil {
+			t.Fatalf("New(%q): %v", c.spec, err)
+		}
+		out, err := fs.Filter([]byte(c.input))
+		if err != nil {
+			t.Errorf("Filter(%q, %q): %v", c.spec, c.input, err)
+			continue
+		}
+		if !json.Valid(out) {
+			t.Errorf("Filter(%q, %q) output is not valid JSON: %s", c.spec, c.input, out)
+		}
+	}
+}
+
+// Fuzz: Filter never panics on arbitrary JSON input with a valid spec.
+func FuzzFilter_NoPanic(f *testing.F) {
+	f.Add("id", `{"id":"123","title":"Test"}`)
+	f.Add("id,title", `[{"id":"1","title":"A"},{"id":"2"}]`)
+	f.Add("assignee.name", `{"assignee":{"name":"Alice"}}`)
+	f.Add("x", `{}`)
+	f.Add("id", `[]`)
+
+	f.Fuzz(func(t *testing.T, spec string, input string) {
+		fs, err := New(spec, nil)
+		if err != nil {
+			return // invalid spec is expected
+		}
+		if fs == nil {
+			return // nil means no filtering
+		}
+		out, err := fs.Filter([]byte(input))
+		if err != nil {
+			return // invalid JSON input is expected
+		}
+		if !json.Valid(out) {
+			t.Errorf("Filter(%q, %q) produced invalid JSON: %s", spec, input, out)
+		}
+	})
+}
+
+// keyInSpec returns true if key is directly in fields or is the parent of a nested field.
+func keyInSpec(key string, fields map[string]bool) bool {
+	if fields[key] {
+		return true
+	}
+	prefix := key + "."
+	for f := range fields {
+		if strings.HasPrefix(f, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func jsonEqual(a, b []byte) bool {
+	var va, vb any
+	if json.Unmarshal(a, &va) != nil || json.Unmarshal(b, &vb) != nil {
+		return false
+	}
+	na, _ := json.Marshal(va)
+	nb, _ := json.Marshal(vb)
+	return string(na) == string(nb)
+}

--- a/internal/fieldfilter/selector_property_test.go
+++ b/internal/fieldfilter/selector_property_test.go
@@ -1,6 +1,7 @@
 package fieldfilter
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -249,5 +250,5 @@ func jsonEqual(a, b []byte) bool {
 	}
 	na, _ := json.Marshal(va)
 	nb, _ := json.Marshal(vb)
-	return string(na) == string(nb)
+	return bytes.Equal(na, nb)
 }

--- a/internal/fieldfilter/selector_property_test.go
+++ b/internal/fieldfilter/selector_property_test.go
@@ -69,8 +69,14 @@ func TestNewForList_PreservesWrapperFields(t *testing.T) {
 			t.Errorf("wrapper field %q missing from output", key)
 		}
 	}
-	nodes := obj["nodes"].([]any)
-	inner := nodes[0].(map[string]any)
+	nodesRaw, ok := obj["nodes"].([]any)
+	if !ok || len(nodesRaw) == 0 {
+		t.Fatal("nodes is missing or empty")
+	}
+	inner, ok := nodesRaw[0].(map[string]any)
+	if !ok {
+		t.Fatal("nodes[0] is not a JSON object")
+	}
 	if _, ok := inner["extra"]; ok {
 		t.Error("inner field 'extra' should have been filtered out")
 	}

--- a/pkg/linear/nullable_property_test.go
+++ b/pkg/linear/nullable_property_test.go
@@ -58,6 +58,14 @@ func TestNullable_RoundTrip(t *testing.T) {
 	})
 }
 
+// UnmarshalJSON returns an error when JSON type doesn't match T.
+func TestNullable_UnmarshalTypeError(t *testing.T) {
+	var n Nullable[int]
+	if err := json.Unmarshal([]byte(`"not-a-number"`), &n); err == nil {
+		t.Error("expected error unmarshaling string into Nullable[int]")
+	}
+}
+
 // Property: the three states are mutually exclusive.
 // For each state: IsSet, IsZero, and Get() must all agree.
 func TestNullable_StateInvariant(t *testing.T) {

--- a/pkg/linear/nullable_property_test.go
+++ b/pkg/linear/nullable_property_test.go
@@ -45,7 +45,10 @@ func TestNullable_RoundTrip(t *testing.T) {
 	t.Run("int values", func(t *testing.T) {
 		for _, n := range []int{0, 1, -1, 42, 1<<31 - 1, -(1 << 31)} {
 			original := NewValue(n)
-			data, _ := json.Marshal(original)
+			data, err := json.Marshal(original)
+			if err != nil {
+				t.Fatalf("RoundTrip(%d) Marshal: %v", n, err)
+			}
 			var decoded Nullable[int]
 			if err := json.Unmarshal(data, &decoded); err != nil {
 				t.Fatalf("RoundTrip(%d) Unmarshal: %v", n, err)

--- a/pkg/linear/nullable_property_test.go
+++ b/pkg/linear/nullable_property_test.go
@@ -1,0 +1,122 @@
+package linear
+
+import (
+	"encoding/json"
+	"testing"
+	"unicode/utf8"
+)
+
+// Property: marshal → unmarshal is the identity for all three states.
+func TestNullable_RoundTrip(t *testing.T) {
+	t.Run("string values", func(t *testing.T) {
+		for _, s := range []string{"", "hello", `"quoted"`, "with\nnewline", "unicode: 日本語"} {
+			original := NewValue(s)
+			data, err := json.Marshal(original)
+			if err != nil {
+				t.Fatalf("Marshal(%q): %v", s, err)
+			}
+			var decoded Nullable[string]
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("Unmarshal(%q): %v", s, err)
+			}
+			v, ok := decoded.Get()
+			if !ok || v == nil || *v != s {
+				t.Errorf("RoundTrip(%q): got (%v, %v)", s, v, ok)
+			}
+		}
+	})
+
+	t.Run("null", func(t *testing.T) {
+		original := NewNull[string]()
+		data, err := json.Marshal(original)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		var decoded Nullable[string]
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		v, ok := decoded.Get()
+		if !ok || v != nil {
+			t.Errorf("RoundTrip(null): Get() = (%v, %v), want (nil, true)", v, ok)
+		}
+	})
+
+	t.Run("int values", func(t *testing.T) {
+		for _, n := range []int{0, 1, -1, 42, 1<<31 - 1, -(1 << 31)} {
+			original := NewValue(n)
+			data, _ := json.Marshal(original)
+			var decoded Nullable[int]
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("RoundTrip(%d) Unmarshal: %v", n, err)
+			}
+			v, ok := decoded.Get()
+			if !ok || v == nil || *v != n {
+				t.Errorf("RoundTrip(%d): got (%v, %v)", n, v, ok)
+			}
+		}
+	})
+}
+
+// Property: the three states are mutually exclusive.
+// For each state: IsSet, IsZero, and Get() must all agree.
+func TestNullable_StateInvariant(t *testing.T) {
+	cases := []struct {
+		name  string
+		n     Nullable[string]
+		isSet bool
+		isNil bool // whether Get() returns a nil pointer
+	}{
+		{"unset", NewUnset[string](), false, true},
+		{"null", NewNull[string](), true, true},
+		{"value", NewValue("x"), true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.n.IsSet(); got != c.isSet {
+				t.Errorf("IsSet() = %v, want %v", got, c.isSet)
+			}
+			// IsZero is the inverse of IsSet for omitempty
+			if got := c.n.IsZero(); got != !c.isSet {
+				t.Errorf("IsZero() = %v, want %v", got, !c.isSet)
+			}
+			v, ok := c.n.Get()
+			if ok != c.isSet {
+				t.Errorf("Get() ok = %v, want %v", ok, c.isSet)
+			}
+			if (v == nil) != c.isNil {
+				t.Errorf("Get() v==nil is %v, want %v", v == nil, c.isNil)
+			}
+		})
+	}
+}
+
+// Fuzz: marshal→unmarshal round-trip for valid UTF-8 strings never panics and preserves value.
+// JSON requires valid UTF-8; encoding/json replaces invalid bytes with U+FFFD, so the
+// round-trip invariant is only guaranteed for valid UTF-8 strings.
+func FuzzNullable_RoundTrip(f *testing.F) {
+	f.Add("hello")
+	f.Add("")
+	f.Add(`"quoted"`)
+	f.Add("null")
+	f.Add("unicode: 日本語")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		if !utf8.ValidString(s) {
+			return // JSON round-trip only preserves valid UTF-8
+		}
+		original := NewValue(s)
+		data, err := json.Marshal(original)
+		if err != nil {
+			t.Fatalf("Marshal error: %v", err)
+		}
+		var decoded Nullable[string]
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("Unmarshal error: %v", err)
+		}
+		v, ok := decoded.Get()
+		if !ok || v == nil || *v != s {
+			t.Errorf("RoundTrip(%q): got (%v, %v)", s, v, ok)
+		}
+	})
+}


### PR DESCRIPTION
Adds invariant and fuzz tests for three pure-function packages:
- Nullable[T]: round-trip identity, state exclusivity, UTF-8 fuzz
- dateparser: monotonicity, UTC midnight, named date ordering, no-panic fuzz
- fieldfilter: idempotency, output-is-subset, valid JSON output, no-panic fuzz
Also fixes two test quality issues: swallowed Marshal error and unsafe type assertions.