### PR TITLE
Update Dependabot schedule and cooldown settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
       day: "monday"
       time: "09:00"
       timezone: "America/Los_Angeles"
@@ -29,13 +29,13 @@ updates:
           - "minor"
           - "patch"
     cooldown:
-      default-days: 7
+      default-days: 3
 
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
       day: "monday"
       time: "09:00"
       timezone: "America/Los_Angeles"
@@ -49,4 +49,4 @@ updates:
       prefix: "chore"
       include: "scope"
     cooldown:
-      default-days: 7
+      default-days: 3


### PR DESCRIPTION
Changed the update schedule for Go modules and GitHub Actions from monthly to weekly. Reduced the cooldown period for updates from 7 days to 3 days.