### PR TITLE
chore(go.mod): bump to go 1.26.3 and run go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,13 @@
 module github.com/chainguard-sandbox/go-linear/v2
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/Yamashou/gqlgenc v0.33.0
 	github.com/chainguard-dev/clog v1.8.0
 	github.com/codeGROOVE-dev/fido v1.11.0
 	github.com/codeGROOVE-dev/fido/pkg/store/localfs v1.11.0
+	github.com/modelcontextprotocol/go-sdk v1.4.1
 	github.com/njayp/ophis v1.1.4
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
@@ -33,7 +34,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
-	github.com/modelcontextprotocol/go-sdk v1.4.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect


### PR DESCRIPTION
Fixes govulncheck failures, example:

  https://github.com/chainguard-sandbox/go-linear/actions/runs/26621013699/job/78446696427?pr=95

and lint github CI failures, example:

  https://github.com/chainguard-sandbox/go-linear/actions/runs/26621013685/job/78446696337?pr=95