### PR TITLE
chore(deps): bump Go to 1.26.4 to clear stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chainguard-sandbox/go-linear/v2
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Yamashou/gqlgenc v0.33.0


### PR DESCRIPTION
Bumps the `go` directive from `1.26.3` to `1.26.4`.

## Why
go1.26.4 fixes two standard-library vulnerabilities that govulncheck reports as **reachable** in this codebase, causing the `Vulnerability Scan` check to fail (exit 3) on every branch:

- **GO-2026-5039** — `net/textproto` (reached via the HTTP transport)
- **GO-2026-5037** — `crypto/x509` (reached via the MCP transport / TLS path)

This is the repo-wide CI blocker shadowing the other open PRs (including #97).

## Verification
- `govulncheck ./...` → **0 affecting vulnerabilities** (was exit 3)
- `go build ./...` and `go test ./...` pass under go1.26.4
- `go mod tidy` touches only the `go` directive (no go.sum churn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
