### PR TITLE
fix(dateparser): reject overflowing duration amounts

### DIFF
--- a/internal/dateparser/parser.go
+++ b/internal/dateparser/parser.go
@@ -8,6 +8,7 @@ package dateparser
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -15,6 +16,33 @@ import (
 )
 
 var durationRegex = regexp.MustCompile(`^(\d+)([hdwm])$`)
+
+// relativeDuration converts a parsed amount and unit (h/d/w/m) into a
+// time.Duration magnitude. It rejects amounts large enough to overflow int64
+// nanoseconds, which would otherwise silently wrap and invert the offset
+// direction (e.g. a huge "Nd" making Parse return a future time).
+func relativeDuration(amount int, unit string) (time.Duration, error) {
+	var unitDur time.Duration
+	switch unit {
+	case "h":
+		unitDur = time.Hour
+	case "d":
+		unitDur = 24 * time.Hour
+	case "w":
+		unitDur = 7 * 24 * time.Hour
+	case "m":
+		unitDur = 30 * 24 * time.Hour // approximate: 30 days per month
+	default:
+		return 0, fmt.Errorf("invalid duration unit: %s", unit)
+	}
+	// unitDur is always > 0 here (the default branch returns before this point),
+	// so the integer division is safe; dividing MaxInt64 by unitDur first yields
+	// the largest amount that won't overflow the subsequent multiplication.
+	if time.Duration(amount) > time.Duration(math.MaxInt64)/unitDur {
+		return 0, fmt.Errorf("duration amount too large: %d%s", amount, unit)
+	}
+	return time.Duration(amount) * unitDur, nil
+}
 
 // Parser parses date strings in various formats.
 type Parser struct{}
@@ -67,21 +95,14 @@ func (p Parser) Parse(input string) (time.Time, error) {
 		}
 
 		unit := matches[2]
-		var duration time.Duration
+		duration, err := relativeDuration(amount, unit)
+		if err != nil {
+			return time.Time{}, err
+		}
 
-		switch unit {
-		case "h":
+		if unit == "h" {
 			// Hours preserve wall-clock time; no midnight truncation.
-			return now.Add(-time.Duration(amount) * time.Hour), nil
-		case "d":
-			duration = time.Duration(amount) * 24 * time.Hour
-		case "w":
-			duration = time.Duration(amount) * 7 * 24 * time.Hour
-		case "m":
-			// Approximate: 30 days per month
-			duration = time.Duration(amount) * 30 * 24 * time.Hour
-		default:
-			return time.Time{}, fmt.Errorf("invalid duration unit: %s", unit)
+			return now.Add(-duration), nil
 		}
 
 		result := now.Add(-duration) // Subtract duration from now
@@ -138,19 +159,9 @@ func (p Parser) ParseFuture(input string) (time.Time, error) {
 		}
 
 		unit := matches[2]
-		var duration time.Duration
-
-		switch unit {
-		case "h":
-			duration = time.Duration(amount) * time.Hour
-		case "d":
-			duration = time.Duration(amount) * 24 * time.Hour
-		case "w":
-			duration = time.Duration(amount) * 7 * 24 * time.Hour
-		case "m":
-			duration = time.Duration(amount) * 30 * 24 * time.Hour
-		default:
-			return time.Time{}, fmt.Errorf("invalid duration unit: %s", unit)
+		duration, err := relativeDuration(amount, unit)
+		if err != nil {
+			return time.Time{}, err
 		}
 
 		return now.Add(duration), nil

--- a/internal/dateparser/parser_test.go
+++ b/internal/dateparser/parser_test.go
@@ -283,3 +283,46 @@ func TestMustParse(t *testing.T) {
 	}()
 	p.MustParse("invalid")
 }
+
+// TestParse_DurationOverflow is a regression for #88: large duration amounts
+// must be rejected with an error, not silently overflow int64 nanoseconds and
+// invert the offset direction.
+func TestParse_DurationOverflow(t *testing.T) {
+	p := New()
+	now := time.Now().UTC()
+
+	// Amounts just past the per-unit overflow threshold (these previously
+	// wrapped, e.g. Parse("106752d") returned a date in the future).
+	overflowing := []string{"106752d", "2562048h", "15251w", "3559m", "99999999999d"}
+	for _, in := range overflowing {
+		if _, err := p.Parse(in); err == nil {
+			t.Errorf("Parse(%q): expected overflow error, got nil", in)
+		}
+		if _, err := p.ParseFuture(in); err == nil {
+			t.Errorf("ParseFuture(%q): expected overflow error, got nil", in)
+		}
+	}
+
+	// Large-but-valid amounts must still parse and keep their direction:
+	// Parse in the past, ParseFuture in the future. "2562047h" is the largest
+	// valid hour amount (2562048h is the first to overflow), so it guards the
+	// max-valid boundary directly below the overflow threshold above.
+	for _, in := range []string{"3650d", "1000w", "100m", "2562047h"} {
+		past, err := p.Parse(in)
+		if err != nil {
+			t.Errorf("Parse(%q): unexpected error: %v", in, err)
+			continue
+		}
+		if !past.Before(now) {
+			t.Errorf("Parse(%q) = %v, want a past time", in, past)
+		}
+		future, err := p.ParseFuture(in)
+		if err != nil {
+			t.Errorf("ParseFuture(%q): unexpected error: %v", in, err)
+			continue
+		}
+		if !future.After(now) {
+			t.Errorf("ParseFuture(%q) = %v, want a future time", in, future)
+		}
+	}
+}


### PR DESCRIPTION
`Parse` and `ParseFuture` computed `time.Duration(amount) * unit` without bounds, so large amounts (e.g. `106752d`) silently overflowed int64 nanoseconds and **inverted the offset direction** — `Parse` returned a future time and `ParseFuture` a past one, with no error.

## Fix
Extract the shared unit→duration conversion into `relativeDuration`, which rejects any amount that would exceed `math.MaxInt64` for its unit. This also removes the duplicated switch between `Parse` and `ParseFuture`.

## Verification
- New `TestParse_DurationOverflow`: amounts past each per-unit threshold now error; large-but-valid amounts still parse and keep direction (Parse=past, ParseFuture=future).
- `go test ./internal/dateparser/` and `golangci-lint` pass.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)
