### PR TITLE
fix(notification): snooze-until uses future-direction parser

### DIFF
--- a/cmd/linear/commands/notification/notification_test.go
+++ b/cmd/linear/commands/notification/notification_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/chainguard-sandbox/go-linear/v2/internal/testutil"
 )
@@ -72,6 +73,64 @@ func TestRunUpdate(t *testing.T) {
 			t.Fatalf("Execute() error = %v", err)
 		}
 	})
+}
+
+// TestRunUpdate_SnoozeUntilIsFuture is a regression for #74: snooze-until must
+// be parsed in the future direction, so a relative input like "3d" produces a
+// future timestamp rather than one 3 days in the past.
+func TestRunUpdate_SnoozeUntilIsFuture(t *testing.T) {
+	server, lastVars := testutil.MockServerCapture(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewUpdateCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"notif-123", "--snooze-until=3d"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	vars := lastVars()
+	if vars == nil {
+		t.Fatal("no variables captured")
+	}
+	input, ok := vars["input"].(map[string]any)
+	if !ok {
+		t.Fatalf("variables[input] = %T, want map", vars["input"])
+	}
+	raw, ok := input["snoozedUntilAt"].(string)
+	if !ok {
+		t.Fatalf("input[snoozedUntilAt] = %T, want string", input["snoozedUntilAt"])
+	}
+	got, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		t.Fatalf("snoozedUntilAt %q not RFC3339: %v", raw, err)
+	}
+	// Assert against a lower bound two days out (the input is "3d") rather than
+	// time.Now(): this documents the expected magnitude and stays robust if the
+	// fixture's duration ever shrinks toward minutes.
+	if !got.After(time.Now().Add(2 * 24 * time.Hour)) {
+		t.Errorf("snooze-until=3d sent %v, want a future time at least 2 days out (regression #74)", got)
+	}
+}
+
+// TestRunUpdate_SnoozeUntilRejectsPast is the negative half of #74: because
+// snooze-until now parses in the future direction, an explicitly past date must
+// be rejected rather than silently accepted.
+func TestRunUpdate_SnoozeUntilRejectsPast(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	cmd := NewUpdateCommand(factory)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"notif-123", "--snooze-until=2020-01-01"})
+	if err := cmd.Execute(); err == nil {
+		t.Error("snooze-until=2020-01-01 (a past date) should be rejected, got nil error")
+	}
 }
 
 func TestNewSubscribeCommand(t *testing.T) {

--- a/cmd/linear/commands/notification/update.go
+++ b/cmd/linear/commands/notification/update.go
@@ -58,7 +58,9 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, notificationID string)
 
 	if snoozeUntilStr != "" {
 		parser := dateparser.New()
-		snoozeUntil, err := parser.Parse(snoozeUntilStr)
+		// Snooze targets a future time, so relative durations ("3d") mean
+		// "from now" and past/"today" inputs are rejected.
+		snoozeUntil, err := parser.ParseFuture(snoozeUntilStr)
 		if err != nil {
 			return fmt.Errorf("invalid snooze-until date: %w", err)
 		}


### PR DESCRIPTION
`notification update --snooze-until` called `dateparser.Parse`, which treats relative durations as offsets into the **past** (`3d` = 3 days ago) and accepts `today`/`yesterday`. Snooze targets a future time, so this used the wrong parser direction.

## Fix
Use `ParseFuture`: `3d` now means 3 days from now, and past/`today` inputs are rejected. This matches `notification snooze-all`, which already used `ParseFuture`.

## Verification
- New `TestRunUpdate_SnoozeUntilIsFuture` captures the GraphQL variables and asserts `snoozedUntilAt` is in the future (would have failed before the fix).
- `go test ./cmd/linear/commands/notification/` and `golangci-lint` pass.

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)
