### PR TITLE
refactor(cli): read confirmation prompts from cmd.InOrStdin()

### DIFF
--- a/cmd/linear/commands/attachment/delete.go
+++ b/cmd/linear/commands/attachment/delete.go
@@ -3,7 +3,6 @@ package attachment
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -36,7 +35,7 @@ Related: attachment_get, issue_get`,
 			if !confirmFlags.Yes {
 				fmt.Fprintf(cmd.OutOrStderr(), "Delete attachment %s? This cannot be undone.\n", args[0])
 				fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
-				reader := bufio.NewReader(os.Stdin)
+				reader := bufio.NewReader(cmd.InOrStdin())
 				response, _ := reader.ReadString('\n')
 				if !strings.EqualFold(strings.TrimSpace(response), "yes") {
 					fmt.Fprintln(cmd.OutOrStderr(), "Canceled.")

--- a/cmd/linear/commands/comment/comment_test.go
+++ b/cmd/linear/commands/comment/comment_test.go
@@ -175,3 +175,45 @@ func TestRunDelete(t *testing.T) {
 		}
 	})
 }
+
+// TestRunDelete_InteractiveConfirmation exercises the confirmation prompt via an
+// injected reader (cmd.SetIn) — possible only because #84 switched the prompt
+// from os.Stdin to cmd.InOrStdin().
+func TestRunDelete_InteractiveConfirmation(t *testing.T) {
+	server := testutil.MockServer(t, defaultHandlers())
+	defer server.Close()
+	factory := testutil.TestFactory(t, server.URL)
+
+	t.Run("yes proceeds with delete", func(t *testing.T) {
+		cmd := NewDeleteCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetIn(strings.NewReader("yes\n"))
+		cmd.SetArgs([]string{"comment-123"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if !strings.Contains(buf.String(), "success") {
+			t.Errorf("expected success output after confirming, got: %s", buf.String())
+		}
+	})
+
+	t.Run("no cancels without deleting", func(t *testing.T) {
+		cmd := NewDeleteCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetIn(strings.NewReader("no\n"))
+		cmd.SetArgs([]string{"comment-123"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		// "Canceled." is written to cmd.OutOrStderr(), which returns the SetOut
+		// writer when one is set, so it lands in buf alongside any stdout.
+		if !strings.Contains(buf.String(), "Canceled") {
+			t.Errorf("expected cancellation message, got: %s", buf.String())
+		}
+		if strings.Contains(buf.String(), "success") {
+			t.Errorf("delete should not run when not confirmed, got: %s", buf.String())
+		}
+	})
+}

--- a/cmd/linear/commands/comment/delete.go
+++ b/cmd/linear/commands/comment/delete.go
@@ -3,7 +3,6 @@ package comment
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -48,7 +47,7 @@ func runDelete(cmd *cobra.Command, client *linear.Client, commentID string, conf
 		fmt.Fprintf(cmd.OutOrStderr(), "Are you sure you want to delete comment %s? This cannot be undone.\n", commentID)
 		fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
 
-		reader := bufio.NewReader(os.Stdin)
+		reader := bufio.NewReader(cmd.InOrStdin())
 		response, _ := reader.ReadString('\n')
 		response = strings.TrimSpace(response)
 

--- a/cmd/linear/commands/document/delete.go
+++ b/cmd/linear/commands/document/delete.go
@@ -3,7 +3,6 @@ package document
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -49,7 +48,7 @@ func runDelete(cmd *cobra.Command, client *linear.Client, documentID string, con
 	if !confirmFlags.Yes {
 		fmt.Fprintf(cmd.OutOrStderr(), "Delete document %s? This cannot be undone.\n", documentID)
 		fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
-		reader := bufio.NewReader(os.Stdin)
+		reader := bufio.NewReader(cmd.InOrStdin())
 		response, _ := reader.ReadString('\n')
 		if !strings.EqualFold(strings.TrimSpace(response), "yes") {
 			fmt.Fprintln(cmd.OutOrStderr(), "Canceled.")

--- a/cmd/linear/commands/initiative/delete.go
+++ b/cmd/linear/commands/initiative/delete.go
@@ -3,7 +3,6 @@ package initiative
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -36,7 +35,7 @@ Related: initiative_list, initiative_get`,
 			if !confirmFlags.Yes {
 				fmt.Fprintf(cmd.OutOrStderr(), "Delete initiative %s? This cannot be undone.\n", args[0])
 				fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
-				reader := bufio.NewReader(os.Stdin)
+				reader := bufio.NewReader(cmd.InOrStdin())
 				response, _ := reader.ReadString('\n')
 				if !strings.EqualFold(strings.TrimSpace(response), "yes") {
 					fmt.Fprintln(cmd.OutOrStderr(), "Canceled.")

--- a/cmd/linear/commands/initiative/status_update_archive.go
+++ b/cmd/linear/commands/initiative/status_update_archive.go
@@ -3,7 +3,6 @@ package initiative
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -49,7 +48,7 @@ func runStatusUpdateArchive(cmd *cobra.Command, client *linear.Client, updateID 
 	if !confirmFlags.Yes {
 		fmt.Fprintf(cmd.OutOrStderr(), "Archive initiative status update %s? This cannot be undone.\n", updateID)
 		fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
-		reader := bufio.NewReader(os.Stdin)
+		reader := bufio.NewReader(cmd.InOrStdin())
 		response, _ := reader.ReadString('\n')
 		if !strings.EqualFold(strings.TrimSpace(response), "yes") {
 			fmt.Fprintln(cmd.OutOrStderr(), "Canceled.")

--- a/cmd/linear/commands/issue/batch_update.go
+++ b/cmd/linear/commands/issue/batch_update.go
@@ -3,7 +3,6 @@ package issue
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -324,7 +323,7 @@ func runBatchUpdate(cmd *cobra.Command, client *linear.Client) error {
 	if !yes {
 		fmt.Fprintf(cmd.OutOrStderr(), "⚠️  Update %d issues? This will modify existing data.\n", len(issues))
 		fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
-		reader := bufio.NewReader(os.Stdin)
+		reader := bufio.NewReader(cmd.InOrStdin())
 		response, _ := reader.ReadString('\n')
 		if !strings.EqualFold(strings.TrimSpace(response), "yes") {
 			fmt.Fprintln(cmd.OutOrStderr(), "Canceled.")

--- a/cmd/linear/commands/issue/unrelate.go
+++ b/cmd/linear/commands/issue/unrelate.go
@@ -3,7 +3,6 @@ package issue
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -49,7 +48,7 @@ func runUnrelate(cmd *cobra.Command, client *linear.Client, relationID string) e
 		fmt.Fprintf(cmd.OutOrStderr(), "⚠️  Are you sure you want to delete this issue relation? This cannot be undone.\n")
 		fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
 
-		reader := bufio.NewReader(os.Stdin)
+		reader := bufio.NewReader(cmd.InOrStdin())
 		response, _ := reader.ReadString('\n')
 		response = strings.TrimSpace(response)
 

--- a/cmd/linear/commands/label/delete.go
+++ b/cmd/linear/commands/label/delete.go
@@ -3,7 +3,6 @@ package label
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -45,7 +44,7 @@ Related: label_list, label_get`,
 			if !confirmFlags.Yes {
 				fmt.Fprintf(cmd.OutOrStderr(), "Delete label %s? This cannot be undone.\n", args[0])
 				fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
-				reader := bufio.NewReader(os.Stdin)
+				reader := bufio.NewReader(cmd.InOrStdin())
 				response, _ := reader.ReadString('\n')
 				if !strings.EqualFold(strings.TrimSpace(response), "yes") {
 					fmt.Fprintln(cmd.OutOrStderr(), "Canceled.")

--- a/cmd/linear/commands/project/delete.go
+++ b/cmd/linear/commands/project/delete.go
@@ -3,7 +3,6 @@ package project
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -36,7 +35,7 @@ Related: project_list, project_get`,
 			if !confirmFlags.Yes {
 				fmt.Fprintf(cmd.OutOrStderr(), "Delete project %s? This cannot be undone.\n", args[0])
 				fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
-				reader := bufio.NewReader(os.Stdin)
+				reader := bufio.NewReader(cmd.InOrStdin())
 				response, _ := reader.ReadString('\n')
 				if !strings.EqualFold(strings.TrimSpace(response), "yes") {
 					fmt.Fprintln(cmd.OutOrStderr(), "Canceled.")

--- a/cmd/linear/commands/project/label_delete.go
+++ b/cmd/linear/commands/project/label_delete.go
@@ -3,7 +3,6 @@ package project
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -47,7 +46,7 @@ func runLabelDelete(cmd *cobra.Command, client *linear.Client, labelID string, c
 	if !confirmFlags.Yes {
 		fmt.Fprintf(cmd.OutOrStderr(), "Delete project label %s? This cannot be undone.\n", labelID)
 		fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
-		reader := bufio.NewReader(os.Stdin)
+		reader := bufio.NewReader(cmd.InOrStdin())
 		response, _ := reader.ReadString('\n')
 		if !strings.EqualFold(strings.TrimSpace(response), "yes") {
 			fmt.Fprintln(cmd.OutOrStderr(), "Canceled.")

--- a/cmd/linear/commands/project/milestone_delete.go
+++ b/cmd/linear/commands/project/milestone_delete.go
@@ -3,7 +3,6 @@ package project
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -48,7 +47,7 @@ func runMilestoneDelete(cmd *cobra.Command, client *linear.Client, milestoneID s
 		fmt.Fprintf(cmd.OutOrStderr(), "⚠️  Are you sure you want to delete this milestone? This cannot be undone.\n")
 		fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
 
-		reader := bufio.NewReader(os.Stdin)
+		reader := bufio.NewReader(cmd.InOrStdin())
 		response, _ := reader.ReadString('\n')
 		response = strings.TrimSpace(response)
 

--- a/cmd/linear/commands/project/relation_delete.go
+++ b/cmd/linear/commands/project/relation_delete.go
@@ -3,7 +3,6 @@ package project
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -47,7 +46,7 @@ func runRelationDelete(cmd *cobra.Command, client *linear.Client, relationID str
 	if !confirmFlags.Yes {
 		fmt.Fprintf(cmd.OutOrStderr(), "Delete project relation %s? This cannot be undone.\n", relationID)
 		fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
-		reader := bufio.NewReader(os.Stdin)
+		reader := bufio.NewReader(cmd.InOrStdin())
 		response, _ := reader.ReadString('\n')
 		if !strings.EqualFold(strings.TrimSpace(response), "yes") {
 			fmt.Fprintln(cmd.OutOrStderr(), "Canceled.")

--- a/cmd/linear/commands/project/status_update_delete.go
+++ b/cmd/linear/commands/project/status_update_delete.go
@@ -3,7 +3,6 @@ package project
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -49,7 +48,7 @@ func runStatusUpdateDelete(cmd *cobra.Command, client *linear.Client, updateID s
 	if !confirmFlags.Yes {
 		fmt.Fprintf(cmd.OutOrStderr(), "Delete project status update %s? This cannot be undone.\n", updateID)
 		fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
-		reader := bufio.NewReader(os.Stdin)
+		reader := bufio.NewReader(cmd.InOrStdin())
 		response, _ := reader.ReadString('\n')
 		if !strings.EqualFold(strings.TrimSpace(response), "yes") {
 			fmt.Fprintln(cmd.OutOrStderr(), "Canceled.")

--- a/cmd/linear/commands/team/delete.go
+++ b/cmd/linear/commands/team/delete.go
@@ -3,7 +3,6 @@ package team
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -44,7 +43,7 @@ Related: team_list, team_get`,
 			if !confirmFlags.Yes {
 				fmt.Fprintf(cmd.OutOrStderr(), "Delete team %s? This CANNOT be undone.\n", args[0])
 				fmt.Fprint(cmd.OutOrStderr(), "Type 'yes' to confirm: ")
-				reader := bufio.NewReader(os.Stdin)
+				reader := bufio.NewReader(cmd.InOrStdin())
 				response, _ := reader.ReadString('\n')
 				if !strings.EqualFold(strings.TrimSpace(response), "yes") {
 					fmt.Fprintln(cmd.OutOrStderr(), "Canceled.")


### PR DESCRIPTION
Fourteen delete/confirm commands read the confirmation response directly from `os.Stdin`, which made the interactive prompt path untestable and was inconsistent with `issue delete` (already using `cmd.InOrStdin()`).

## Fix
Switch them to `bufio.NewReader(cmd.InOrStdin())` and drop the now-unused `os` imports. No user-facing change: `InOrStdin()` returns `os.Stdin` when no reader is set.

## Verification
- Tests can now inject input via `cmd.SetIn()`; adds a confirmation test for `comment delete` exercising both the `yes` and `no` paths.
- `go build ./...`, `go vet ./...`, and `golangci-lint` pass.

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)
