### PR TITLE
fix(linear): re-export server-side filter and result types

### DIFF
--- a/pkg/linear/client_issues.go
+++ b/pkg/linear/client_issues.go
@@ -386,8 +386,8 @@ func (c *Client) IssueUnarchive(ctx context.Context, id string) error {
 //	term := "login"
 //	first := int64(50)
 //	priorityHigh := float64(2)
-//	filter := &intgraphql.IssueFilter{
-//	    Priority: &intgraphql.NullableNumberComparator{Eq: &priorityHigh},
+//	filter := &linear.IssueFilter{
+//	    Priority: &linear.NullableNumberComparator{Eq: &priorityHigh},
 //	}
 //	issues, err := client.SearchIssues(ctx, term, &first, nil, filter, nil)
 //

--- a/pkg/linear/types.go
+++ b/pkg/linear/types.go
@@ -166,3 +166,65 @@ type ProjectCreateInput = intgraphql.ProjectCreateInput
 //
 // See internal/graphql/models.go for complete field list.
 type ProjectUpdateInput = intgraphql.ProjectUpdateInput
+
+// Server-side filter and result types re-exported from internal/graphql.
+//
+// IssuesFiltered, SearchIssues, and ProjectsFiltered take these filter types
+// and return these result types. Because internal/graphql cannot be imported
+// from outside the module, external consumers could see the method signatures
+// but never construct the arguments or use the returns. Re-exporting via type
+// aliases closes that gap without changing the generated implementation (#85).
+
+// IssueFilter is the server-side filter for IssuesFiltered and SearchIssues.
+// See internal/graphql/models.go for the complete field list (And/Or plus
+// per-field comparators).
+type IssueFilter = intgraphql.IssueFilter
+
+// ProjectFilter is the server-side filter for ProjectsFiltered.
+// See internal/graphql/models.go for the complete field list.
+type ProjectFilter = intgraphql.ProjectFilter
+
+// Result-type alias names intentionally mirror the generated gqlgenc type
+// names so go doc shows the same identifier for the method return and the
+// alias; ST1003 (underscores) is suppressed for that reason.
+
+// ListIssuesFiltered_Issues is the paginated result of IssuesFiltered
+// (Nodes + PageInfo).
+type ListIssuesFiltered_Issues = intgraphql.ListIssuesFiltered_Issues //nolint:staticcheck // ST1003: mirrors generated gqlgenc result type name
+
+// SearchIssues_SearchIssues is the paginated result of SearchIssues
+// (Nodes + PageInfo + TotalCount).
+type SearchIssues_SearchIssues = intgraphql.SearchIssues_SearchIssues //nolint:staticcheck // ST1003: mirrors generated gqlgenc result type name
+
+// ListProjectsFiltered_Projects is the paginated result of ProjectsFiltered
+// (Nodes + PageInfo).
+type ListProjectsFiltered_Projects = intgraphql.ListProjectsFiltered_Projects //nolint:staticcheck // ST1003: mirrors generated gqlgenc result type name
+
+// Filter leaf types — the nested-filter and comparator types used by the fields
+// of IssueFilter and ProjectFilter. Without these, the filter aliases above are
+// only nameable, not populatable: a consumer could declare an IssueFilter but
+// not set a single condition, because every field is typed with an internal
+// type. This is the common subset covering project / state / assignee / priority
+// / id / date / string filtering. The full transitive set is large and tracks
+// the generated models, so it will be emitted automatically alongside the
+// gqlgenc generation in a follow-up (see #85); these hand-written aliases cover
+// the frequent cases until then.
+//
+// The first group are nested filters reachable from common IssueFilter /
+// ProjectFilter fields; the second are terminal scalar comparators whose own
+// fields are plain scalars/slices.
+type (
+	WorkflowStateFilter   = intgraphql.WorkflowStateFilter   // IssueFilter.State
+	NullableProjectFilter = intgraphql.NullableProjectFilter // IssueFilter.Project
+	NullableUserFilter    = intgraphql.NullableUserFilter    // IssueFilter.Assignee / Creator / ...
+
+	IDComparator             = intgraphql.IDComparator
+	IssueIDComparator        = intgraphql.IssueIDComparator
+	NumberComparator         = intgraphql.NumberComparator
+	NullableNumberComparator = intgraphql.NullableNumberComparator
+	StringComparator         = intgraphql.StringComparator
+	NullableStringComparator = intgraphql.NullableStringComparator
+	DateComparator           = intgraphql.DateComparator
+	NullableDateComparator   = intgraphql.NullableDateComparator
+	BooleanComparator        = intgraphql.BooleanComparator
+)

--- a/pkg/linear/types_external_test.go
+++ b/pkg/linear/types_external_test.go
@@ -1,0 +1,45 @@
+package linear_test
+
+import (
+	"testing"
+
+	"github.com/chainguard-sandbox/go-linear/v2/pkg/linear"
+)
+
+// TestFilterTypesUsableExternally is a regression for #85: the server-side
+// filter and result types for IssuesFiltered / SearchIssues / ProjectsFiltered
+// must be both nameable AND populatable purely through the public pkg/linear,
+// since external consumers cannot import internal/graphql.
+//
+// This is a compile-time check — it fails to build (not at runtime) if any of
+// the re-exported aliases are removed.
+func TestFilterTypesUsableExternally(t *testing.T) {
+	projectID := "proj_123"
+	stateType := "started"
+	assignedToMe := true
+	var minPriority float64 = 2
+
+	// A consumer can build a *populated* issue filter — project + state +
+	// assignee + priority — without touching internal/graphql.
+	filter := linear.IssueFilter{
+		Project:  &linear.NullableProjectFilter{ID: &linear.IDComparator{Eq: &projectID}},
+		State:    &linear.WorkflowStateFilter{Type: &linear.StringComparator{Eq: &stateType}},
+		Assignee: &linear.NullableUserFilter{IsMe: &linear.BooleanComparator{Eq: &assignedToMe}},
+		Priority: &linear.NullableNumberComparator{Gte: &minPriority},
+	}
+	// Compound And/Or recursion is usable through the public type too.
+	filter.And = []*linear.IssueFilter{{ID: &linear.IssueIDComparator{Eq: &projectID}}}
+	_ = filter
+
+	// ProjectFilter is likewise populatable (filter projects by name).
+	name := "Platform"
+	pf := linear.ProjectFilter{Name: &linear.StringComparator{Contains: &name}}
+	_ = pf
+
+	// Paginated result types remain nameable through the public package.
+	var (
+		_ *linear.ListIssuesFiltered_Issues
+		_ *linear.SearchIssues_SearchIssues
+		_ *linear.ListProjectsFiltered_Projects
+	)
+}


### PR DESCRIPTION
`IssuesFiltered`, `SearchIssues`, and `ProjectsFiltered` are exported on `linear.Client`, but their `*IssueFilter`/`*ProjectFilter` parameters and paginated return types come from the unexported `internal/graphql` package. External consumers can read the method signatures but cannot import those types, so the methods are uncallable from outside the module — forcing callers to fetch the whole workspace and filter in memory.

## Fix
Re-export, via type aliases in `pkg/linear`:

- **Filter inputs**: `IssueFilter`, `ProjectFilter`
- **Paginated results**: `ListIssuesFiltered_Issues`, `SearchIssues_SearchIssues`, `ListProjectsFiltered_Projects` (alias names mirror the generated gqlgenc types; `ST1003` suppressed with an explained directive on those lines)
- **Filter leaf types** (so the filters are *populatable*, not just nameable): the nested filters (`WorkflowStateFilter`, `NullableProjectFilter`, `NullableUserFilter`) and scalar comparators (`IDComparator`, `IssueIDComparator`, `NumberComparator`, `NullableNumberComparator`, `StringComparator`, `NullableStringComparator`, `DateComparator`, `NullableDateComparator`, `BooleanComparator`) used by the common fields — covering project / state / assignee / priority / id / date / string filtering.

Also fixes the `SearchIssues` doc example to reference the public `linear.*` names instead of the unimportable `intgraphql.*` path.

## Scope
This is the **common subset** for issue/project filtering — the issue's headline cases. The same internal-type leak affects other `*Filtered` methods (comments, attachments, cycles, documents, labels, audit) and the long tail of comparators. Because that full set is large and tracks the generated models, it will be emitted **automatically alongside gqlgenc generation** as a follow-up during the SDK sync (#45), rather than hand-maintained here.

## Verification
- `pkg/linear/types_external_test.go` (`package linear_test`) builds a **populated** `IssueFilter` (project + state + assignee + priority + `And` recursion) and a `ProjectFilter`, purely through `pkg/linear` — a compile-time regression guard.
- `go build ./...`, `go test ./pkg/linear/`, `go vet`, and `golangci-lint` (0 issues) pass; `go doc` exposes the types.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)
