### PR TITLE
test: address property-test gaps flagged in PR #87 review

### DIFF
--- a/internal/dateparser/parser_property_test.go
+++ b/internal/dateparser/parser_property_test.go
@@ -34,6 +34,16 @@ func mustParse(t *testing.T, p Parser, input string) time.Time {
 	return result
 }
 
+// mustParseFuture is the ParseFuture analog of mustParse.
+func mustParseFuture(t *testing.T, p Parser, input string) time.Time {
+	t.Helper()
+	result, err := p.ParseFuture(input)
+	if err != nil {
+		t.Fatalf("ParseFuture(%q): unexpected error: %v", input, err)
+	}
+	return result
+}
+
 // Property: larger N in "Nd" → earlier timestamp (strictly monotonic).
 func TestParse_RelativeDay_Monotonic(t *testing.T) {
 	p := New()
@@ -95,9 +105,281 @@ func TestParse_ResultsAreUTCMidnight(t *testing.T) {
 	}
 }
 
+// Property: "Nh" preserves wall-clock time — unlike d/w/m it is not truncated to midnight.
+// Verified by comparing Parse("24h") (no truncation) with Parse("1d") (midnight truncation):
+// they must differ unless the test runs exactly at midnight UTC.
+func TestParse_HoursNotTruncated(t *testing.T) {
+	p := New()
+	before := time.Now().UTC()
+	if before.Equal(before.Truncate(24 * time.Hour)) {
+		t.Skip("running at midnight UTC; hour/day truncation indistinguishable")
+	}
+	day := mustParse(t, p, "1d")
+	if day.Hour() != 0 || day.Minute() != 0 || day.Second() != 0 {
+		t.Fatalf("1d result %v is not midnight UTC — assumption broken", day)
+	}
+	hour, err := p.Parse("24h")
+	if err != nil {
+		t.Fatalf("Parse(\"24h\"): %v", err)
+	}
+	after := time.Now().UTC()
+	// Skip if a UTC date boundary was crossed during the two Parse calls: when
+	// Parse("24h")'s internal time.Now() lands at midnight, the result equals the
+	// midnight-truncated 1d result through coincidence, not a truncation bug.
+	if !before.Truncate(24 * time.Hour).Equal(after.Truncate(24 * time.Hour)) {
+		t.Skip("execution straddled midnight UTC; result indeterminate")
+	}
+	if hour.Equal(day) {
+		t.Errorf("Parse(\"24h\") == Parse(\"1d\") (%v); hours should not be truncated to midnight", hour)
+	}
+}
+
+// Property: all future results are after the time the test started.
+// N=0 is intentionally excluded from Nd inputs: ParseFuture("0d") returns now+0=now,
+// which is not strictly after the pre-call timestamp.
+func TestParseFuture_RelativeDatesAreFuture(t *testing.T) {
+	p := New()
+	for _, n := range []int{1, 2, 7, 14, 30, 90, 365} {
+		input := fmt.Sprintf("%dd", n)
+		before := time.Now().UTC()
+		result, err := p.ParseFuture(input)
+		if err != nil {
+			t.Fatalf("ParseFuture(%q): %v", input, err)
+		}
+		if !result.After(before) {
+			t.Errorf("ParseFuture(%q) = %v is not after pre-call timestamp (%v)", input, result, before)
+		}
+	}
+	for _, input := range []string{"1w", "2w", "1m", "3m"} {
+		before := time.Now().UTC()
+		result, err := p.ParseFuture(input)
+		if err != nil {
+			t.Fatalf("ParseFuture(%q): %v", input, err)
+		}
+		if !result.After(before) {
+			t.Errorf("ParseFuture(%q) = %v is not after pre-call timestamp (%v)", input, result, before)
+		}
+	}
+}
+
+// Property: larger N → later timestamp (monotonic, opposite direction from Parse).
+// Covers d/w/m units and cross-unit ordering (2w < 1m since 14d < 30d).
+func TestParseFuture_RelativeDay_Monotonic(t *testing.T) {
+	p := New()
+	pairs := [][2]int{{1, 2}, {2, 7}, {7, 14}, {14, 30}, {30, 90}, {90, 365}}
+	for _, pair := range pairs {
+		smaller, larger := pair[0], pair[1]
+		t1 := mustParseFuture(t, p, fmt.Sprintf("%dd", smaller))
+		t2 := mustParseFuture(t, p, fmt.Sprintf("%dd", larger))
+		if !t2.After(t1) {
+			t.Errorf("%dd (%v) should be before %dd (%v)", smaller, t1, larger, t2)
+		}
+	}
+	wPairs := [][2]string{{"1w", "2w"}, {"1m", "2m"}, {"2m", "3m"}, {"2w", "1m"}}
+	for _, pair := range wPairs {
+		t1 := mustParseFuture(t, p, pair[0])
+		t2 := mustParseFuture(t, p, pair[1])
+		if !t2.After(t1) {
+			t.Errorf("%s (%v) should be before %s (%v)", pair[0], t1, pair[1], t2)
+		}
+	}
+}
+
+// Property: ParseFuture rejects "yesterday" and "today"; accepts "tomorrow".
+func TestParseFuture_NamedDateRejections(t *testing.T) {
+	p := New()
+	for _, rejected := range []string{"yesterday", "today"} {
+		if _, err := p.ParseFuture(rejected); err == nil {
+			t.Errorf("ParseFuture(%q) expected error, got nil", rejected)
+		}
+	}
+	result, err := p.ParseFuture("tomorrow")
+	if err != nil {
+		t.Fatalf("ParseFuture(\"tomorrow\"): unexpected error: %v", err)
+	}
+	if result.Location() != time.UTC {
+		t.Errorf("ParseFuture(\"tomorrow\") location = %v, want UTC", result.Location())
+	}
+}
+
+// Property: ParseFuture does not truncate any unit to midnight — all preserve wall-clock time.
+// This contrasts with Parse where only "h" is exempt from midnight truncation.
+// Each input is a t.Run subtest so that a midnight skip on one input does not
+// silently discard the remaining inputs.
+func TestParseFuture_NoMidnightTruncation(t *testing.T) {
+	p := New()
+	for _, input := range []string{"1h", "1d", "2w", "3m", "tomorrow"} {
+		t.Run(input, func(t *testing.T) {
+			before := time.Now().UTC()
+			if before.Equal(before.Truncate(24 * time.Hour)) {
+				t.Skip("running at midnight UTC; truncation indistinguishable from no truncation")
+			}
+			result, err := p.ParseFuture(input)
+			if err != nil {
+				t.Fatalf("ParseFuture(%q): %v", input, err)
+			}
+			after := time.Now().UTC()
+			// Skip if a UTC date boundary was crossed during this ParseFuture call:
+			// when the internal time.Now() lands at midnight, the result is correctly
+			// midnight, indistinguishable from a truncation bug.
+			if !before.Truncate(24 * time.Hour).Equal(after.Truncate(24 * time.Hour)) {
+				t.Skip("execution straddled midnight UTC; result indeterminate")
+			}
+			// Use Truncate rather than H/M/S: 00:00:00.5 has H=M=S=0 but is not midnight.
+			if result.Equal(result.Truncate(24 * time.Hour)) {
+				t.Errorf("ParseFuture(%q) = %v: expected wall-clock time, not midnight", input, result)
+			}
+		})
+	}
+}
+
+// Property: ParseFuture rejects past RFC3339 datetimes (parser.go line ~137).
+func TestParseFuture_PastRFC3339Rejected(t *testing.T) {
+	p := New()
+	if _, err := p.ParseFuture("2000-01-01T00:00:00Z"); err == nil {
+		t.Error("ParseFuture(\"2000-01-01T00:00:00Z\") expected error for past datetime, got nil")
+	}
+}
+
+// Property: ParseFuture rejects a past date-only ISO 8601 string (parser.go line ~128).
+func TestParseFuture_PastISODateRejected(t *testing.T) {
+	p := New()
+	if _, err := p.ParseFuture("2000-01-01"); err == nil {
+		t.Error("ParseFuture(\"2000-01-01\") expected error for past date, got nil")
+	}
+}
+
+// Property: ParseFuture rejects empty string input.
+func TestParseFuture_EmptyStringRejected(t *testing.T) {
+	p := New()
+	if _, err := p.ParseFuture(""); err == nil {
+		t.Error("ParseFuture(\"\") expected error for empty input, got nil")
+	}
+}
+
+// Property: ParseFuture with a date-only ISO 8601 string returns midnight UTC —
+// the same truncation behavior as Parse for absolute dates.
+func TestParseFuture_AbsoluteISODate(t *testing.T) {
+	p := New()
+	result, err := p.ParseFuture("2099-01-01")
+	if err != nil {
+		t.Fatalf("ParseFuture(\"2099-01-01\"): %v", err)
+	}
+	if result.Location() != time.UTC {
+		t.Errorf("location = %v, want UTC", result.Location())
+	}
+	if !result.Equal(result.Truncate(24 * time.Hour)) {
+		t.Errorf("ParseFuture(\"2099-01-01\") = %v, want midnight UTC", result)
+	}
+}
+
+// Property: ParseFuture accepts a future RFC3339 datetime and returns the correct UTC value.
+// Covers the time.Parse(time.RFC3339, input) acceptance path (parser.go lines 135–141).
+func TestParseFuture_FutureRFC3339Accepted(t *testing.T) {
+	p := New()
+	result, err := p.ParseFuture("2099-01-01T15:04:05Z")
+	if err != nil {
+		t.Fatalf("ParseFuture(\"2099-01-01T15:04:05Z\"): %v", err)
+	}
+	if result.Location() != time.UTC {
+		t.Errorf("location = %v, want UTC", result.Location())
+	}
+	if result.Year() != 2099 || result.Month() != 1 || result.Day() != 1 ||
+		result.Hour() != 15 || result.Minute() != 4 || result.Second() != 5 {
+		t.Errorf("ParseFuture(\"2099-01-01T15:04:05Z\") = %v, want 2099-01-01T15:04:05Z", result)
+	}
+}
+
+// Fuzz: ParseFuture never panics; on success result is always UTC.
+func FuzzParseFuture_NoPanic(f *testing.F) {
+	f.Add("7d")
+	f.Add("tomorrow")
+	f.Add("1h")
+	f.Add("2099-01-01")
+	f.Add("2099-01-01T15:04:05Z")
+	f.Add("")
+	f.Add("invalid")
+	f.Add("0d")
+	f.Add("yesterday")            // rejected: not a future date
+	f.Add("2000-01-01T00:00:00Z") // rejected: past RFC3339 datetime
+
+	f.Fuzz(func(t *testing.T, s string) {
+		// Relies on time.Now() being non-decreasing within a single iteration.
+		// An NTP backward step could cause result.Before(before) on a correct implementation,
+		// but this is not a realistic concern in CI.
+		before := time.Now().UTC()
+		p := New()
+		result, err := p.ParseFuture(s)
+		if err != nil {
+			return
+		}
+		if result.Location() != time.UTC {
+			t.Errorf("ParseFuture(%q) succeeded but result is not UTC: %v", s, result)
+		}
+		// N=0 (e.g. "0d") returns now+0 which equals ParseFuture's internal now >= before.
+		if result.Before(before) {
+			t.Errorf("ParseFuture(%q) = %v is before test start %v", s, result, before)
+		}
+	})
+}
+
+// Property: Parse("0d") == today midnight; Parse("0h") is not truncated to midnight;
+// ParseFuture("0d") is not before the pre-call timestamp.
+// Each section is a t.Run subtest so that a midnight skip in one section does not
+// silently suppress the other sections.
+func TestParse_ZeroAmounts(t *testing.T) {
+	p := New()
+
+	t.Run("0d equals today", func(t *testing.T) {
+		// Both calls take their own time.Now(); bracket to skip if a UTC date boundary
+		// is crossed between them.
+		before := time.Now().UTC()
+		if before.Equal(before.Truncate(24 * time.Hour)) {
+			t.Skip("running at midnight UTC; date may shift between Parse calls")
+		}
+		today := mustParse(t, p, "today")
+		zeroDay := mustParse(t, p, "0d")
+		after := time.Now().UTC()
+		if !before.Truncate(24 * time.Hour).Equal(after.Truncate(24 * time.Hour)) {
+			t.Skip("execution straddled midnight UTC; Parse(\"today\") and Parse(\"0d\") may differ by one day")
+		}
+		if !zeroDay.Equal(today) {
+			t.Errorf("Parse(\"0d\") = %v, want today midnight (%v)", zeroDay, today)
+		}
+	})
+
+	t.Run("0h not truncated", func(t *testing.T) {
+		before := time.Now().UTC()
+		if before.Equal(before.Truncate(24 * time.Hour)) {
+			t.Skip("running at midnight UTC; Parse(\"0h\") == midnight is ambiguous")
+		}
+		zeroHour := mustParse(t, p, "0h")
+		after := time.Now().UTC()
+		if !before.Truncate(24 * time.Hour).Equal(after.Truncate(24 * time.Hour)) {
+			t.Skip("execution straddled midnight UTC; Parse(\"0h\") result indeterminate")
+		}
+		if zeroHour.Equal(zeroHour.Truncate(24 * time.Hour)) {
+			t.Errorf("Parse(\"0h\") = %v: should preserve wall-clock time, not truncate to midnight", zeroHour)
+		}
+	})
+
+	t.Run("ParseFuture 0d", func(t *testing.T) {
+		// ParseFuture("0d") adds zero duration to now; result >= the pre-call timestamp.
+		before := time.Now().UTC()
+		result, err := p.ParseFuture("0d")
+		if err != nil {
+			t.Fatalf("ParseFuture(\"0d\"): %v", err)
+		}
+		if result.Before(before) {
+			t.Errorf("ParseFuture(\"0d\") = %v is before pre-call timestamp %v", result, before)
+		}
+	})
+}
+
 // Fuzz: Parse never panics; on success result is always UTC.
 func FuzzParse_NoPanic(f *testing.F) {
 	f.Add("7d")
+	f.Add("1h")
 	f.Add("today")
 	f.Add("2025-12-10")
 	f.Add("2025-12-10T15:04:05Z")
@@ -105,6 +387,8 @@ func FuzzParse_NoPanic(f *testing.F) {
 	f.Add("invalid")
 	f.Add("0d")
 	f.Add("999m")
+	f.Add("9223372036855m") // triggers relativeDuration overflow guard for 'm'
+	f.Add("106751992d")     // triggers relativeDuration overflow guard for 'd'
 
 	f.Fuzz(func(t *testing.T, s string) {
 		p := New()

--- a/internal/fieldfilter/selector_property_test.go
+++ b/internal/fieldfilter/selector_property_test.go
@@ -30,6 +30,48 @@ func TestNew_DefaultsNoCommandDefaults(t *testing.T) {
 	}
 }
 
+// New("defaults,...") propagates parseFields errors from the extra-fields segment.
+func TestNew_DefaultsWithInvalidExtra(t *testing.T) {
+	_, err := New("defaults,id,,title", nil)
+	if err == nil {
+		t.Error("expected error for empty field in defaults extra segment")
+	}
+}
+
+// NewForList with a spec that names a wrapper field: "nodes" appears in both
+// preserveFields and fs.fields, so filterObject takes the preserveFields branch
+// (which applies filterValue recursively) rather than the direct-copy branch.
+// Inner objects must still be filtered to contain only the spec fields.
+func TestNewForList_OverlapPreservesAndFilters(t *testing.T) {
+	fs, err := NewForList("nodes,id", nil)
+	if err != nil {
+		t.Fatalf("NewForList: %v", err)
+	}
+	input := `{"nodes":[{"id":"1","extra":"drop"}],"pageInfo":{"hasNextPage":false},"totalCount":1}`
+	out, err := fs.Filter([]byte(input))
+	if err != nil {
+		t.Fatalf("Filter: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(out, &obj); err != nil {
+		t.Fatalf("output not valid JSON: %v", err)
+	}
+	nodesRaw, ok := obj["nodes"].([]any)
+	if !ok || len(nodesRaw) == 0 {
+		t.Fatal("nodes missing or empty")
+	}
+	inner, ok := nodesRaw[0].(map[string]any)
+	if !ok {
+		t.Fatal("nodes[0] is not a JSON object")
+	}
+	if _, ok := inner["id"]; !ok {
+		t.Error("inner field 'id' should be present")
+	}
+	if _, ok := inner["extra"]; ok {
+		t.Error("inner field 'extra' should have been filtered out by filterValue on the preserveFields path")
+	}
+}
+
 // NewForList returns nil when New returns nil (no filtering requested).
 func TestNewForList_NilPassthrough(t *testing.T) {
 	fs, err := NewForList("none", nil)
@@ -56,7 +98,7 @@ func TestNewForList_PreservesWrapperFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewForList: %v", err)
 	}
-	input := `{"nodes":[{"id":"1","title":"T","extra":"e"}],"pageInfo":{"hasNextPage":false},"totalCount":1}`
+	input := `{"nodes":[{"id":"1","title":"T","extra":"e"}],"pageInfo":{"hasNextPage":false},"totalCount":1,"status":"open"}`
 	out, err := fs.Filter([]byte(input))
 	if err != nil {
 		t.Fatalf("Filter: %v", err)
@@ -70,6 +112,9 @@ func TestNewForList_PreservesWrapperFields(t *testing.T) {
 			t.Errorf("wrapper field %q missing from output", key)
 		}
 	}
+	if _, ok := obj["status"]; ok {
+		t.Error("non-wrapper top-level key 'status' should have been filtered out")
+	}
 	nodesRaw, ok := obj["nodes"].([]any)
 	if !ok || len(nodesRaw) == 0 {
 		t.Fatal("nodes is missing or empty")
@@ -80,6 +125,11 @@ func TestNewForList_PreservesWrapperFields(t *testing.T) {
 	}
 	if _, ok := inner["extra"]; ok {
 		t.Error("inner field 'extra' should have been filtered out")
+	}
+	for _, key := range []string{"id", "title"} {
+		if _, ok := inner[key]; !ok {
+			t.Errorf("inner field %q should be present", key)
+		}
 	}
 }
 
@@ -95,28 +145,42 @@ func TestFilter_InvalidJSON(t *testing.T) {
 // filterValue default branch: scalar values inside an array pass through unchanged.
 func TestFilter_ScalarArrayElements(t *testing.T) {
 	fs, _ := New("id", nil)
-	out, err := fs.Filter([]byte(`["a", "b", "c"]`))
+	want := []string{"a", "b", "c"}
+	input, _ := json.Marshal(want)
+	out, err := fs.Filter(input)
 	if err != nil {
 		t.Fatalf("Filter: %v", err)
 	}
-	if !json.Valid(out) {
-		t.Errorf("output is not valid JSON: %s", out)
+	var got []string
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("output is not a valid JSON string array: %v — output: %s", err, out)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d — output: %s", len(got), len(want), out)
+	}
+	for i, v := range got {
+		if v != want[i] {
+			t.Errorf("[%d] = %q, want %q", i, v, want[i])
+		}
 	}
 }
 
 // Property: Filter is idempotent — applying the same spec twice equals applying it once.
+// Cases with an excludedKey also assert that the first pass actually removes that key,
+// so a no-op Filter implementation cannot pass the test.
 func TestFilter_Idempotent(t *testing.T) {
 	cases := []struct {
-		name  string
-		spec  string
-		input string
+		name        string
+		spec        string
+		input       string
+		excludedKey string // top-level key that must be absent from the first-pass output
 	}{
-		{"simple", "id", `{"id":"123","title":"Test","priority":1}`},
-		{"multi", "id,title", `{"id":"1","title":"T","extra":"e"}`},
-		{"nested", "id,assignee.name", `{"id":"1","assignee":{"name":"Alice","email":"a@b.com"}}`},
-		{"array", "id,title", `[{"id":"1","title":"A","extra":"x"},{"id":"2","title":"B","extra":"y"}]`},
-		{"no match", "missing", `{"id":"1","title":"T"}`},
-		{"empty object", "id", `{}`},
+		{"simple", "id", `{"id":"123","title":"Test","priority":1}`, "priority"},
+		{"multi", "id,title", `{"id":"1","title":"T","extra":"e"}`, "extra"},
+		{"nested", "id,assignee.name", `{"id":"1","assignee":{"name":"Alice","email":"a@b.com"}}`, ""},
+		{"array", "id,title", `[{"id":"1","title":"A","extra":"x"},{"id":"2","title":"B","extra":"y"}]`, ""},
+		{"no match", "missing", `{"id":"1","title":"T"}`, ""},
+		{"empty object", "id", `{}`, ""},
 	}
 
 	for _, c := range cases {
@@ -128,6 +192,14 @@ func TestFilter_Idempotent(t *testing.T) {
 			once, err := fs.Filter([]byte(c.input))
 			if err != nil {
 				t.Fatalf("Filter() first pass: %v", err)
+			}
+			if c.excludedKey != "" {
+				var obj map[string]any
+				if err := json.Unmarshal(once, &obj); err == nil {
+					if _, present := obj[c.excludedKey]; present {
+						t.Errorf("Filter() first pass still contains excluded key %q", c.excludedKey)
+					}
+				}
 			}
 			twice, err := fs.Filter(once)
 			if err != nil {
@@ -144,14 +216,16 @@ func TestFilter_Idempotent(t *testing.T) {
 // (directly or as the parent of a nested selector).
 func TestFilter_OutputIsSubset(t *testing.T) {
 	cases := []struct {
-		name  string
-		spec  string
-		input string
+		name       string
+		spec       string
+		input      string
+		wantObjLen int // expected number of top-level keys in filtered output
 	}{
-		{"simple subset", "id,title", `{"id":"1","title":"T","extra":"e","priority":1}`},
-		{"only id", "id", `{"id":"1","title":"T","extra":"e"}`},
-		{"nested parent key", "assignee.name", `{"id":"1","assignee":{"name":"Alice","email":"a@b.com"}}`},
-		{"nothing matches", "missing", `{"id":"1","title":"T"}`},
+		{"simple subset", "id,title", `{"id":"1","title":"T","extra":"e","priority":1}`, 2},
+		{"only id", "id", `{"id":"1","title":"T","extra":"e"}`, 1},
+		{"nested parent key", "assignee.name", `{"id":"1","assignee":{"name":"Alice","email":"a@b.com"}}`, 1},
+		// "nothing matches" produces {}; wantObjLen=0 makes the subset invariant non-vacuous.
+		{"nothing matches", "missing", `{"id":"1","title":"T"}`, 0},
 	}
 
 	for _, c := range cases {
@@ -169,23 +243,205 @@ func TestFilter_OutputIsSubset(t *testing.T) {
 			if err := json.Unmarshal(out, &obj); err != nil {
 				t.Fatalf("output is not a valid JSON object: %v — output: %s", err, out)
 			}
-			for key := range obj {
-				if !keyInSpec(key, fs.fields) {
-					t.Errorf("output key %q was not requested in spec %q", key, c.spec)
+			if len(obj) != c.wantObjLen {
+				t.Errorf("len(obj) = %d, want %d — output: %s", len(obj), c.wantObjLen, out)
+			}
+			// fs is non-nil for all current cases; this guard is defensive
+			// against future rows that use a spec like "none" (nil selector).
+			if fs != nil {
+				for key := range obj {
+					if !keyInSpec(key, fs.fields) {
+						t.Errorf("output key %q was not requested in spec %q", key, c.spec)
+					}
 				}
 			}
 		})
 	}
 }
 
+// Property: every key in each object of a filtered array was requested in the spec.
+func TestFilter_ArrayOutputIsSubset(t *testing.T) {
+	cases := []struct {
+		name        string
+		spec        string
+		input       string
+		wantArrLen  int
+		wantElemLen int // expected number of top-level keys in each filtered element
+	}{
+		{"array simple", "id,title", `[{"id":"1","title":"A","extra":"x"},{"id":"2","title":"B","extra":"y"}]`, 2, 2},
+		{"array only id", "id", `[{"id":"1","title":"T"},{"id":"2","title":"U"}]`, 2, 1},
+		// "nothing matches" produces [{},{}]; wantElemLen=0 makes the subset invariant non-vacuous.
+		{"array nothing matches", "missing", `[{"id":"1"},{"id":"2"}]`, 2, 0},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fs, err := New(c.spec, nil)
+			if err != nil {
+				t.Fatalf("New(%q): %v", c.spec, err)
+			}
+			out, err := fs.Filter([]byte(c.input))
+			if err != nil {
+				t.Fatalf("Filter(): %v", err)
+			}
+			var arr []map[string]any
+			if err := json.Unmarshal(out, &arr); err != nil {
+				t.Fatalf("output is not a valid JSON array of objects: %v — output: %s", err, out)
+			}
+			if len(arr) != c.wantArrLen {
+				t.Fatalf("len(arr) = %d, want %d — output: %s", len(arr), c.wantArrLen, out)
+			}
+			for i, obj := range arr {
+				if len(obj) != c.wantElemLen {
+					t.Errorf("[%d] len(obj) = %d, want %d — obj: %v", i, len(obj), c.wantElemLen, obj)
+				}
+				for key := range obj {
+					if !keyInSpec(key, fs.fields) {
+						t.Errorf("[%d] key %q was not requested in spec %q", i, key, c.spec)
+					}
+				}
+			}
+		})
+	}
+}
+
+// Property: nested sub-objects inside array elements are also filtered — unrequested keys
+// within a nested object must not leak through.
+func TestFilter_ArrayNestedObjectSubset(t *testing.T) {
+	fs, err := New("assignee.name", nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	input := `[{"id":"1","assignee":{"name":"Alice","email":"x@example.com"},"extra":"drop"}]`
+	out, err := fs.Filter([]byte(input))
+	if err != nil {
+		t.Fatalf("Filter: %v", err)
+	}
+	var arr []map[string]any
+	if err := json.Unmarshal(out, &arr); err != nil {
+		t.Fatalf("output not valid JSON array: %v — output: %s", err, out)
+	}
+	if len(arr) != 1 {
+		t.Fatalf("len(arr) = %d, want 1 — output: %s", len(arr), out)
+	}
+	elem := arr[0]
+	if _, ok := elem["id"]; ok {
+		t.Error("top-level 'id' should have been filtered out")
+	}
+	if _, ok := elem["extra"]; ok {
+		t.Error("top-level 'extra' should have been filtered out")
+	}
+	assignee, ok := elem["assignee"].(map[string]any)
+	if !ok {
+		t.Fatalf("'assignee' missing or not an object — output: %s", out)
+	}
+	if _, ok := assignee["name"]; !ok {
+		t.Error("assignee.name should be present")
+	}
+	if _, ok := assignee["email"]; ok {
+		t.Error("assignee.email should have been filtered out")
+	}
+}
+
+// Property: deeply nested spec (a.b.c) filters recursively through all levels.
+func TestFilter_DeepNested(t *testing.T) {
+	fs, err := New("a.b.c", nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	input := `{"a":{"b":{"c":"keep","d":"drop"},"e":"drop"},"f":"drop"}`
+	out, err := fs.Filter([]byte(input))
+	if err != nil {
+		t.Fatalf("Filter: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("output not valid JSON: %v", err)
+	}
+	a, ok := result["a"].(map[string]any)
+	if !ok {
+		t.Fatalf("output missing key 'a' or not an object — output: %s", out)
+	}
+	b, ok := a["b"].(map[string]any)
+	if !ok {
+		t.Fatalf("output missing key 'a.b' or not an object — output: %s", out)
+	}
+	if _, ok := b["c"]; !ok {
+		t.Errorf("output missing 'a.b.c' — output: %s", out)
+	}
+	if _, ok := b["d"]; ok {
+		t.Error("output contains 'a.b.d', should have been filtered out")
+	}
+	if _, ok := a["e"]; ok {
+		t.Error("output contains 'a.e', should have been filtered out")
+	}
+	if _, ok := result["f"]; ok {
+		t.Error("output contains 'f', should have been filtered out")
+	}
+}
+
+// Property: deeply nested spec (a.b.c) filters recursively even when an intermediate
+// key holds an array — filterObject recurses into each array element via filterValue.
+func TestFilter_DeepNestedArray(t *testing.T) {
+	fs, err := New("a.b.c", nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// "a" is an array; each element has "b.c" to keep plus "b.d" and "e" to drop.
+	input := `{"a":[{"b":{"c":"keep","d":"drop"},"e":"drop"},{"b":{"c":"also-keep","d":"also-drop"},"e":"also-drop"}]}`
+	out, err := fs.Filter([]byte(input))
+	if err != nil {
+		t.Fatalf("Filter: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("output not valid JSON: %v — output: %s", err, out)
+	}
+	aRaw, ok := result["a"].([]any)
+	if !ok {
+		t.Fatalf("'a' missing or not an array — output: %s", out)
+	}
+	if len(aRaw) != 2 {
+		t.Fatalf("len(a) = %d, want 2 — output: %s", len(aRaw), out)
+	}
+	for i, elem := range aRaw {
+		obj, ok := elem.(map[string]any)
+		if !ok {
+			t.Fatalf("a[%d] is not an object", i)
+		}
+		if _, ok := obj["e"]; ok {
+			t.Errorf("a[%d].e should have been filtered out", i)
+		}
+		b, ok := obj["b"].(map[string]any)
+		if !ok {
+			t.Fatalf("a[%d].b missing or not an object", i)
+		}
+		if _, ok := b["c"]; !ok {
+			t.Errorf("a[%d].b.c should be present", i)
+		}
+		if _, ok := b["d"]; ok {
+			t.Errorf("a[%d].b.d should have been filtered out", i)
+		}
+	}
+}
+
 // Property: output is always valid JSON, even when no fields match.
 func TestFilter_AlwaysValidJSON(t *testing.T) {
-	cases := []struct{ spec, input string }{
-		{"id", `{"id":"1","title":"T"}`},
-		{"missing", `{"id":"1","title":"T"}`},
-		{"id,title", `[{"id":"1"},{"id":"2"}]`},
-		{"x", `{}`},
-		{"x", `[]`},
+	cases := []struct {
+		spec       string
+		input      string
+		wantOutput string // if non-empty, exact expected output bytes
+	}{
+		{"id", `{"id":"1","title":"T"}`, ""},
+		{"missing", `{"id":"1","title":"T"}`, ""},
+		{"id,title", `[{"id":"1"},{"id":"2"}]`, ""},
+		{"x", `{}`, ""},
+		{"x", `[]`, ""},
+		// JSON null input: passes through unchanged and re-encodes as "null".
+		{"x", `null`, "null"},
+		// Top-level JSON number and boolean: filterValue default branch passes through.
+		{"x", `42`, "42"},
+		{"x", `true`, "true"},
 	}
 	for _, c := range cases {
 		fs, err := New(c.spec, nil)
@@ -200,6 +456,9 @@ func TestFilter_AlwaysValidJSON(t *testing.T) {
 		if !json.Valid(out) {
 			t.Errorf("Filter(%q, %q) output is not valid JSON: %s", c.spec, c.input, out)
 		}
+		if c.wantOutput != "" && string(out) != c.wantOutput {
+			t.Errorf("Filter(%q, %q) = %s, want %s", c.spec, c.input, out, c.wantOutput)
+		}
 	}
 }
 
@@ -210,6 +469,7 @@ func FuzzFilter_NoPanic(f *testing.F) {
 	f.Add("assignee.name", `{"assignee":{"name":"Alice"}}`)
 	f.Add("x", `{}`)
 	f.Add("id", `[]`)
+	f.Add("a.b.c", `{"a":{"b":{"c":"v","d":"drop"},"e":"drop"}}`) // two-level recursive filterObject path
 
 	f.Fuzz(func(t *testing.T, spec string, input string) {
 		fs, err := New(spec, nil)
@@ -230,6 +490,8 @@ func FuzzFilter_NoPanic(f *testing.F) {
 }
 
 // keyInSpec returns true if key is directly in fields or is the parent of a nested field.
+// Assumes JSON keys do not contain literal dots; a key like "a.b" would match a spec
+// "a.b.c" via the prefix check, mirroring the same assumption in filterObject.
 func keyInSpec(key string, fields map[string]bool) bool {
 	if fields[key] {
 		return true

--- a/pkg/linear/nullable_property_test.go
+++ b/pkg/linear/nullable_property_test.go
@@ -2,6 +2,7 @@ package linear
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 	"unicode/utf8"
 )
@@ -59,6 +60,36 @@ func TestNullable_RoundTrip(t *testing.T) {
 			}
 		}
 	})
+
+	// float64 is the production type for IssueUpdateNullableInput.Estimate.
+	t.Run("float64 values", func(t *testing.T) {
+		for _, f := range []float64{0.0, 1.5, -1.5, 5.0, 1e9} {
+			original := NewValue(f)
+			data, err := json.Marshal(original)
+			if err != nil {
+				t.Fatalf("RoundTrip(%v) Marshal: %v", f, err)
+			}
+			var decoded Nullable[float64]
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("RoundTrip(%v) Unmarshal: %v", f, err)
+			}
+			v, ok := decoded.Get()
+			if !ok || v == nil || *v != f {
+				t.Errorf("RoundTrip(%v): got (%v, %v)", f, v, ok)
+			}
+		}
+	})
+}
+
+// MarshalJSON on Nullable[float64] with NaN or Inf must return an error —
+// encoding/json rejects these as unsupported values. Callers must validate
+// float64 inputs before constructing a Nullable[float64].
+func TestNullable_Float64MarshalError(t *testing.T) {
+	for _, f := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+		if _, err := json.Marshal(NewValue(f)); err == nil {
+			t.Errorf("json.Marshal(NewValue(%v)) expected error, got nil", f)
+		}
+	}
 }
 
 // UnmarshalJSON returns an error when JSON type doesn't match T.
@@ -99,6 +130,34 @@ func TestNullable_StateInvariant(t *testing.T) {
 				t.Errorf("Get() v==nil is %v, want %v", v == nil, c.isNil)
 			}
 		})
+	}
+}
+
+// MarshalJSON on an unset Nullable returns "null" and round-trips to Null (not Unset).
+// This is intentional: the pointer-omitempty approach relies on *Nullable[T] being nil
+// (omitted by omitempty) to represent Unset — if a bare Nullable[T] in the Unset state
+// is ever marshaled directly, it collapses to Null. Callers must use *Nullable[T] with
+// omitempty in struct fields to preserve the three-way distinction over the wire.
+func TestNullable_UnsetMarshalCollapses(t *testing.T) {
+	n := NewUnset[string]()
+	data, err := json.Marshal(n)
+	if err != nil {
+		t.Fatalf("Marshal(Unset): %v", err)
+	}
+	if string(data) != "null" {
+		t.Errorf("Marshal(Unset) = %s, want null", data)
+	}
+	// Unmarshal("null") produces Null state (isSet=true, value=nil), not Unset.
+	var decoded Nullable[string]
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	v, ok := decoded.Get()
+	if !ok {
+		t.Error("decoded.Get() ok = false, want true (Null state, not Unset)")
+	}
+	if v != nil {
+		t.Errorf("decoded.Get() v = %v, want nil (Null state)", v)
 	}
 }
 


### PR DESCRIPTION
Closes the optional gaps Steve flagged in the [PR #87 review](https://github.com/chainguard-sandbox/go-linear/pull/87).

## Changes

**`pkg/linear/nullable_property_test.go`**
- `TestNullable_UnsetMarshalCollapses` — asserts and documents that marshaling a bare `Unset` `Nullable[T]` emits `"null"` and round-trips to `Null` state (not `Unset`). The comment explains why: the pointer-omitempty contract requires callers to use `*Nullable[T]` in struct fields so the nil pointer is omitted before `MarshalJSON` is called.

**`internal/fieldfilter/selector_property_test.go`**
- `TestFilter_ScalarArrayElements` — strengthened from `json.Valid` to a full value comparison; a regression that drops or corrupts scalars now fails.
- `TestFilter_ArrayOutputIsSubset` — new test covering array-of-objects inputs; verifies the subset invariant holds for every element (three cases: multi-field, single-field, no-match).
- `TestFilter_DeepNested` — new test for `a.b.c` style specs; exercises the recursive `filterObject` path through three levels and asserts dropped keys at each level.

**`internal/dateparser/parser_property_test.go`**
- `TestParse_HoursNotTruncated` — locks in the intentional asymmetry: `Parse("24h")` preserves wall-clock time while `Parse("1d")` truncates to midnight UTC.
- `TestParseFuture_RelativeDatesAreFuture` — all `Nd` results are after `time.Now()`.
- `TestParseFuture_RelativeDay_Monotonic` — larger N → later timestamp (opposite direction from `Parse`).
- `TestParseFuture_NamedDateRejections` — `yesterday`/`today` error; `tomorrow` succeeds.
- `TestParseFuture_NoMidnightTruncation` — unlike `Parse`, `ParseFuture` does not truncate any unit (h/d/w/m) to midnight.
- `FuzzParseFuture_NoPanic` — fuzz harness for `ParseFuture`; asserts no panic and UTC location on success.
- `FuzzParse_NoPanic` — added `"1h"` corpus seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)