### PR TITLE
fix(issue): run --link-pr in nullable update path

### DIFF
--- a/cmd/linear/commands/issue/update.go
+++ b/cmd/linear/commands/issue/update.go
@@ -1,6 +1,7 @@
 package issue
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -263,22 +264,33 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 	}
 
 	// Link GitHub PR if specified
-	if prURL, _ := cmd.Flags().GetString("link-pr"); prURL != "" {
-		// Convert short format (owner/repo#123) to full URL if needed
-		fullURL := prURL
-		if !contains(prURL, "://") {
-			// Assume GitHub format: owner/repo#123
-			fullURL = "https://github.com/" + prURL
-		}
-
-		_, err := client.AttachmentLinkGitHubPR(ctx, resolvedIssueID, fullURL)
-		if err != nil {
-			return fmt.Errorf("failed to link GitHub PR: %w", err)
-		}
+	if err := linkGitHubPR(ctx, cmd, client, resolvedIssueID); err != nil {
+		return err
 	}
 
 	// Format output
 	return formatter.FormatJSON(cmd.OutOrStdout(), result, true)
+}
+
+// linkGitHubPR links a GitHub PR to the issue if --link-pr is specified.
+func linkGitHubPR(ctx context.Context, cmd *cobra.Command, client *linear.Client, issueID string) error {
+	prURL, _ := cmd.Flags().GetString("link-pr")
+	if prURL == "" {
+		return nil
+	}
+
+	// Convert short format (owner/repo#123) to full URL if needed
+	fullURL := prURL
+	if !contains(prURL, "://") {
+		// Assume GitHub format: owner/repo#123
+		fullURL = "https://github.com/" + prURL
+	}
+
+	_, err := client.AttachmentLinkGitHubPR(ctx, issueID, fullURL)
+	if err != nil {
+		return fmt.Errorf("failed to link GitHub PR: %w", err)
+	}
+	return nil
 }
 
 // contains checks if a string contains a substring
@@ -450,6 +462,11 @@ func runUpdateWithNullable(cmd *cobra.Command, client *linear.Client, issueID st
 	result, err := client.IssueUpdateNullable(ctx, issueID, input)
 	if err != nil {
 		return fmt.Errorf("failed to update issue: %w", err)
+	}
+
+	// Link GitHub PR if specified
+	if err := linkGitHubPR(ctx, cmd, client, issueID); err != nil {
+		return err
 	}
 
 	// Format output

--- a/cmd/linear/commands/issue/update_test.go
+++ b/cmd/linear/commands/issue/update_test.go
@@ -30,7 +30,7 @@ func TestNewUpdateCommand(t *testing.T) {
 			"title", "description", "assignee", "state",
 			"priority", "estimate", "cycle", "project", "parent",
 			"add-label", "remove-label",
-			"due-date", "milestone",
+			"due-date", "milestone", "link-pr",
 		}
 		for _, flag := range expectedFlags {
 			if cmd.Flags().Lookup(flag) == nil {
@@ -225,12 +225,19 @@ func TestRunUpdate(t *testing.T) {
 }
 
 type updateCapture struct {
-	Input map[string]any
+	Input      map[string]any
+	LinkPRVars map[string]any
 }
 
 func captureUpdateServer(t *testing.T) (*httptest.Server, *updateCapture) {
+	return captureUpdateServerWithLinkPR(t, `{"data":{"attachmentLinkGitHubPR":{"success":true,"attachment":{"id":"att-1"}}}}`)
+}
+
+func captureUpdateServerWithLinkPR(t *testing.T, linkPRResponse string) (*httptest.Server, *updateCapture) {
 	t.Helper()
 	captured := &updateCapture{}
+	handlers := defaultHandlers()
+	handlers["AttachmentLinkGitHubPR"] = linkPRResponse
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		var reqBody struct {
@@ -246,7 +253,9 @@ func captureUpdateServer(t *testing.T) (*httptest.Server, *updateCapture) {
 				captured.Input = input
 			}
 		}
-		handlers := defaultHandlers()
+		if strings.EqualFold(reqBody.OperationName, "AttachmentLinkGitHubPR") {
+			captured.LinkPRVars = reqBody.Variables
+		}
 		for key, resp := range handlers {
 			if strings.EqualFold(key, reqBody.OperationName) {
 				_, _ = w.Write([]byte(resp))
@@ -310,4 +319,112 @@ func TestRunUpdate_EstimatePayload(t *testing.T) {
 			t.Errorf("estimate = %v, want nil (explicit null)", estimateVal)
 		}
 	})
+}
+
+func TestRunUpdate_LinkPR(t *testing.T) {
+	// wantURL values for short-format inputs reflect the current
+	// owner/repo#N -> https://github.com/owner/repo#N conversion, not a
+	// canonical GitHub PR URL shape.
+	// TODO(#115): fix the conversion to produce /pull/N and update these
+	// expectations together with it.
+	tests := []struct {
+		name    string
+		args    []string
+		wantURL string
+	}{
+		{
+			name:    "link-pr with estimate in nullable path",
+			args:    []string{"ENG-123", "--estimate=5", "--link-pr=owner/repo#1"},
+			wantURL: "https://github.com/owner/repo#1",
+		},
+		{
+			name:    "link-pr with assignee none in nullable path",
+			args:    []string{"ENG-123", "--assignee=none", "--link-pr=owner/repo#2"},
+			wantURL: "https://github.com/owner/repo#2",
+		},
+		{
+			name:    "link-pr with title in standard path",
+			args:    []string{"ENG-123", "--title=x", "--link-pr=owner/repo#3"},
+			wantURL: "https://github.com/owner/repo#3",
+		},
+		{
+			name:    "link-pr with full URL passed through unchanged",
+			args:    []string{"ENG-123", "--estimate=5", "--link-pr=https://github.com/owner/repo/pull/4"},
+			wantURL: "https://github.com/owner/repo/pull/4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, captured := captureUpdateServer(t)
+			defer server.Close()
+			factory := func() (*linear.Client, error) {
+				return linear.NewClient("test_api_key", linear.WithBaseURL(server.URL))
+			}
+
+			cmd := NewUpdateCommand(factory)
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			cmd.SetArgs(tt.args)
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+
+			if captured.LinkPRVars == nil {
+				t.Fatal("no AttachmentLinkGitHubPR mutation captured")
+			}
+			if got := captured.LinkPRVars["url"]; got != tt.wantURL {
+				t.Errorf("url = %v, want %q", got, tt.wantURL)
+			}
+			if got := captured.LinkPRVars["issueId"]; got != "issue-123" {
+				t.Errorf("issueId = %v, want %q", got, "issue-123")
+			}
+		})
+	}
+}
+
+// A failed link mutation must surface as an error even though the issue
+// update itself already succeeded.
+func TestRunUpdate_LinkPRError(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "nullable path",
+			args: []string{"ENG-123", "--estimate=5", "--link-pr=owner/repo#1"},
+		},
+		{
+			name: "standard path",
+			args: []string{"ENG-123", "--title=x", "--link-pr=owner/repo#1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, captured := captureUpdateServerWithLinkPR(t, `{"data":{"attachmentLinkGitHubPR":{"success":false}}}`)
+			defer server.Close()
+			factory := func() (*linear.Client, error) {
+				return linear.NewClient("test_api_key", linear.WithBaseURL(server.URL))
+			}
+
+			cmd := NewUpdateCommand(factory)
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected error when AttachmentLinkGitHubPR fails")
+			}
+			if !strings.Contains(err.Error(), "failed to link GitHub PR") {
+				t.Errorf("error = %q, want it to mention failing to link the GitHub PR", err)
+			}
+			if captured.LinkPRVars == nil {
+				t.Error("no AttachmentLinkGitHubPR mutation captured; error came from the wrong place")
+			}
+		})
+	}
 }


### PR DESCRIPTION
`linear issue update` silently drops `--link-pr` whenever the update routes through the nullable path: any use of `--estimate`, or `--assignee`/`--parent`/`--cycle`/`--project`/`--due-date`/`--milestone` set to `none`. The command exits 0 and prints the updated issue, but the PR attachment is never created.

This extracts the `AttachmentLinkGitHubPR` call into a `linkGitHubPR` helper and invokes it from both `runUpdate` and `runUpdateWithNullable` after a successful update.

Tests cover the regression (`--estimate=5 --link-pr`), a second nullable trigger (`--assignee=none --link-pr`), the standard path, and full-URL passthrough; the nullable subtests fail without the fix.

Out of scope (pre-existing, can file separately): `--link-pr` used alone still hits the "no fields to update" guard, and the short-format conversion produces `owner/repo#N` as a fragment URL rather than `/pull/N`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)