### PR TITLE
fix(mcp): return ok=false from asJSONObjectMap and asJSONString for JSON null

### DIFF
--- a/cmd/linear/mcp_transport.go
+++ b/cmd/linear/mcp_transport.go
@@ -112,6 +112,9 @@ func asJSONObjectMap(raw json.RawMessage) (map[string]json.RawMessage, bool) {
 	if err := json.Unmarshal(raw, &m); err != nil {
 		return nil, false
 	}
+	if m == nil { // JSON null unmarshals without error into a nil map
+		return nil, false
+	}
 	return m, true
 }
 

--- a/cmd/linear/mcp_transport.go
+++ b/cmd/linear/mcp_transport.go
@@ -69,6 +69,8 @@ func fixDoubleEncodedFlags(raw json.RawMessage) (json.RawMessage, error) {
 		return nil, err
 	}
 
+	// JSON null unmarshals to a nil map without error; the "arguments" lookup
+	// below misses on a nil map, so null params fall through to (nil, nil).
 	argsRaw, ok := params["arguments"]
 	if !ok {
 		return nil, nil
@@ -120,11 +122,14 @@ func asJSONObjectMap(raw json.RawMessage) (map[string]json.RawMessage, bool) {
 
 // asJSONString returns the string value if raw is a JSON string, else ("", false).
 func asJSONString(raw json.RawMessage) (string, bool) {
-	var s string
+	var s *string
 	if err := json.Unmarshal(raw, &s); err != nil {
 		return "", false
 	}
-	return s, true
+	if s == nil { // JSON null unmarshals without error into a nil pointer
+		return "", false
+	}
+	return *s, true
 }
 
 // asJSONObject returns data as a RawMessage if it is a valid JSON object, else (nil, false).

--- a/cmd/linear/mcp_transport_test.go
+++ b/cmd/linear/mcp_transport_test.go
@@ -153,6 +153,8 @@ func TestAsJSONObjectMap(t *testing.T) {
 			wantOK: false,
 		},
 		{
+			// encoding/json accepts surrounding whitespace, so this is
+			// caught by the nil-map guard, not the parse-error path.
 			name:   "whitespace-padded null is rejected",
 			input:  ` null `,
 			wantOK: false,
@@ -226,6 +228,83 @@ func TestAsJSONObjectMap(t *testing.T) {
 				if _, present := m[tt.wantKey]; !present {
 					t.Errorf("asJSONObjectMap(%q) missing expected key %q: %v", tt.input, tt.wantKey, m)
 				}
+			}
+		})
+	}
+}
+
+func TestAsJSONString(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		wantOK bool
+		want   string // expected value when wantOK
+	}{
+		{
+			name:   "null is rejected",
+			input:  `null`,
+			wantOK: false,
+		},
+		{
+			// encoding/json accepts surrounding whitespace, so this is
+			// caught by the nil-pointer guard, not the parse-error path.
+			name:   "whitespace-padded null is rejected",
+			input:  ` null `,
+			wantOK: false,
+		},
+		{
+			name:   "string is accepted",
+			input:  `"s"`,
+			wantOK: true,
+			want:   "s",
+		},
+		{
+			name:   "empty string is accepted",
+			input:  `""`,
+			wantOK: true,
+			want:   "",
+		},
+		{
+			name:   "object is rejected",
+			input:  `{}`,
+			wantOK: false,
+		},
+		{
+			name:   "array is rejected",
+			input:  `["s"]`,
+			wantOK: false,
+		},
+		{
+			name:   "scalar number is rejected",
+			input:  `42`,
+			wantOK: false,
+		},
+		{
+			name:   "empty input is rejected",
+			input:  ``,
+			wantOK: false,
+		},
+		{
+			name:   "malformed JSON is rejected",
+			input:  `"unterminated`,
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, ok := asJSONString(json.RawMessage(tt.input))
+			if ok != tt.wantOK {
+				t.Fatalf("asJSONString(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
+			}
+			if !ok {
+				if s != "" {
+					t.Errorf("asJSONString(%q) returned %q with ok=false, want empty string", tt.input, s)
+				}
+				return
+			}
+			if s != tt.want {
+				t.Errorf("asJSONString(%q) = %q, want %q", tt.input, s, tt.want)
 			}
 		})
 	}

--- a/cmd/linear/mcp_transport_test.go
+++ b/cmd/linear/mcp_transport_test.go
@@ -137,6 +137,100 @@ func TestFixDoubleEncodedFlags(t *testing.T) {
 	}
 }
 
+// asJSONObjectMap returns ok=false for anything that is not a JSON object.
+// JSON null is the subtle case: json.Unmarshal accepts null into a map with a
+// nil error and a nil map, so it must be rejected explicitly.
+func TestAsJSONObjectMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantOK  bool
+		wantKey string // if set, key must be present in the returned map
+	}{
+		{
+			name:   "null is rejected",
+			input:  `null`,
+			wantOK: false,
+		},
+		{
+			name:   "whitespace-padded null is rejected",
+			input:  ` null `,
+			wantOK: false,
+		},
+		{
+			name:   "empty object is accepted",
+			input:  `{}`,
+			wantOK: true,
+		},
+		{
+			name:    "object with key is accepted",
+			input:   `{"a":1}`,
+			wantOK:  true,
+			wantKey: "a",
+		},
+		{
+			name:    "object with nested object value is accepted",
+			input:   `{"a":{"b":1}}`,
+			wantOK:  true,
+			wantKey: "a",
+		},
+		{
+			name:    "object with multiple keys is accepted",
+			input:   `{"a":1,"b":2}`,
+			wantOK:  true,
+			wantKey: "b",
+		},
+		{
+			name:   "empty input is rejected",
+			input:  ``,
+			wantOK: false,
+		},
+		{
+			name:   "array is rejected",
+			input:  `[1]`,
+			wantOK: false,
+		},
+		{
+			name:   "scalar number is rejected",
+			input:  `42`,
+			wantOK: false,
+		},
+		{
+			name:   "scalar string is rejected",
+			input:  `"s"`,
+			wantOK: false,
+		},
+		{
+			name:   "malformed JSON is rejected",
+			input:  `{malformed`,
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, ok := asJSONObjectMap(json.RawMessage(tt.input))
+			if ok != tt.wantOK {
+				t.Fatalf("asJSONObjectMap(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
+			}
+			if !ok {
+				if m != nil {
+					t.Errorf("asJSONObjectMap(%q) returned non-nil map %v with ok=false", tt.input, m)
+				}
+				return
+			}
+			if m == nil {
+				t.Errorf("asJSONObjectMap(%q) returned nil map with ok=true", tt.input)
+			}
+			if tt.wantKey != "" {
+				if _, present := m[tt.wantKey]; !present {
+					t.Errorf("asJSONObjectMap(%q) missing expected key %q: %v", tt.input, tt.wantKey, m)
+				}
+			}
+		})
+	}
+}
+
 // Outer-params parse error must be returned to the caller, not swallowed.
 func TestFixDoubleEncodedFlags_OuterParseError(t *testing.T) {
 	cases := []string{


### PR DESCRIPTION
Follow-up hardening to the helpers extracted in #86, which shared a contract defect: `json.Unmarshal` of JSON null succeeds without error for both target shapes, so `asJSONObjectMap(null)` returned `(nil, true)` (nil map) and `asJSONString(null)` returned `("", true)` (no-op into a plain string) — each contradicting its docstring ("ok is false if raw is not a JSON object/string").

The map helper gains a nil-map guard (`{}` unmarshals non-nil, so exactly null is rejected, whitespace-padded included). The string helper now unmarshals into `*string` — null yields a nil pointer — while `""` still unmarshals to a non-nil pointer and is accepted.

No observable behavior change at the current call sites: null arguments took the same "nothing to fix" path via safe nil-map reads, and a null flags value produced `""`, which `asJSONObject` already rejected via its length guard. The helpers are now safe for future callers. A comment also documents why the nil params map in `fixDoubleEncodedFlags` is safe as-is.

Direct table-driven tests lock both guards; the null cases fail without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)