### PR TITLE
fix(issue): convert --link-pr short format to a canonical PR URL

### DIFF
--- a/cmd/linear/commands/issue/update.go
+++ b/cmd/linear/commands/issue/update.go
@@ -62,6 +62,12 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 	ctx := cmd.Context()
 	res := resolver.New(client)
 
+	// Validate --link-pr before any API call so an invalid value cannot
+	// leave the issue partially updated.
+	if _, err := resolveLinkPRURL(cmd); err != nil {
+		return err
+	}
+
 	// Resolve issue ID (converts identifier like ENG-123 to UUID)
 	resolvedIssueID, err := res.ResolveIssue(ctx, issueID)
 	if err != nil {
@@ -280,24 +286,39 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 // '_' and may start or end with any of them (e.g. myorg/.github).
 var shortPRFormat = regexp.MustCompile(`^([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)/([A-Za-z0-9._-]+)#([0-9]+)$`)
 
-// linkGitHubPR links a GitHub PR to the issue if --link-pr is specified.
-func linkGitHubPR(ctx context.Context, cmd *cobra.Command, client *linear.Client, issueID string) error {
+// resolveLinkPRURL validates the --link-pr flag value and converts the
+// short format (owner/repo#123) to a canonical GitHub PR URL. Returns ""
+// when the flag is unset.
+func resolveLinkPRURL(cmd *cobra.Command) (string, error) {
 	prURL, _ := cmd.Flags().GetString("link-pr")
 	if prURL == "" {
+		return "", nil
+	}
+
+	// Full URLs bypass local validation deliberately: the attachment API
+	// accepts PR URLs on any host (e.g. GitHub Enterprise).
+	if contains(prURL, "://") {
+		return prURL, nil
+	}
+
+	m := shortPRFormat.FindStringSubmatch(prURL)
+	if m == nil {
+		return "", fmt.Errorf("invalid --link-pr value %q: expected owner/repo#number or a full URL", prURL)
+	}
+	return fmt.Sprintf("https://github.com/%s/%s/pull/%s", m[1], m[2], m[3]), nil
+}
+
+// linkGitHubPR links a GitHub PR to the issue if --link-pr is specified.
+func linkGitHubPR(ctx context.Context, cmd *cobra.Command, client *linear.Client, issueID string) error {
+	fullURL, err := resolveLinkPRURL(cmd)
+	if err != nil {
+		return err
+	}
+	if fullURL == "" {
 		return nil
 	}
 
-	// Convert short format (owner/repo#123) to a canonical GitHub PR URL
-	fullURL := prURL
-	if !contains(prURL, "://") {
-		m := shortPRFormat.FindStringSubmatch(prURL)
-		if m == nil {
-			return fmt.Errorf("invalid --link-pr value %q: expected owner/repo#number or a full URL", prURL)
-		}
-		fullURL = fmt.Sprintf("https://github.com/%s/%s/pull/%s", m[1], m[2], m[3])
-	}
-
-	_, err := client.AttachmentLinkGitHubPR(ctx, issueID, fullURL)
+	_, err = client.AttachmentLinkGitHubPR(ctx, issueID, fullURL)
 	if err != nil {
 		return fmt.Errorf("failed to link GitHub PR: %w", err)
 	}

--- a/cmd/linear/commands/issue/update.go
+++ b/cmd/linear/commands/issue/update.go
@@ -3,6 +3,7 @@ package issue
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -272,6 +273,9 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 	return formatter.FormatJSON(cmd.OutOrStdout(), result, true)
 }
 
+// shortPRFormat matches the owner/repo#number short format accepted by --link-pr.
+var shortPRFormat = regexp.MustCompile(`^([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)/([A-Za-z0-9._-]+)#([0-9]+)$`)
+
 // linkGitHubPR links a GitHub PR to the issue if --link-pr is specified.
 func linkGitHubPR(ctx context.Context, cmd *cobra.Command, client *linear.Client, issueID string) error {
 	prURL, _ := cmd.Flags().GetString("link-pr")
@@ -279,11 +283,14 @@ func linkGitHubPR(ctx context.Context, cmd *cobra.Command, client *linear.Client
 		return nil
 	}
 
-	// Convert short format (owner/repo#123) to full URL if needed
+	// Convert short format (owner/repo#123) to a canonical GitHub PR URL
 	fullURL := prURL
 	if !contains(prURL, "://") {
-		// Assume GitHub format: owner/repo#123
-		fullURL = "https://github.com/" + prURL
+		m := shortPRFormat.FindStringSubmatch(prURL)
+		if m == nil {
+			return fmt.Errorf("invalid --link-pr value %q: expected owner/repo#number or a full URL", prURL)
+		}
+		fullURL = fmt.Sprintf("https://github.com/%s/%s/pull/%s", m[1], m[2], m[3])
 	}
 
 	_, err := client.AttachmentLinkGitHubPR(ctx, issueID, fullURL)

--- a/cmd/linear/commands/issue/update.go
+++ b/cmd/linear/commands/issue/update.go
@@ -273,7 +273,11 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 	return formatter.FormatJSON(cmd.OutOrStdout(), result, true)
 }
 
-// shortPRFormat matches the owner/repo#number short format accepted by --link-pr.
+// shortPRFormat matches the owner/repo#number short format accepted by
+// --link-pr. The owner and repo groups are deliberately asymmetric,
+// mirroring GitHub's naming rules: owners are alphanumeric-and-hyphen and
+// cannot start or end with a hyphen, while repo names also allow '.' and
+// '_' and may start or end with any of them (e.g. myorg/.github).
 var shortPRFormat = regexp.MustCompile(`^([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)/([A-Za-z0-9._-]+)#([0-9]+)$`)
 
 // linkGitHubPR links a GitHub PR to the issue if --link-pr is specified.

--- a/cmd/linear/commands/issue/update_test.go
+++ b/cmd/linear/commands/issue/update_test.go
@@ -396,6 +396,7 @@ func TestRunUpdate_LinkPRInvalidFormat(t *testing.T) {
 		{name: "non-numeric number", linkPR: "owner/repo#abc"},
 		{name: "extra path segment", linkPR: "owner/repo/extra#1"},
 		{name: "leading hyphen in owner", linkPR: "-owner/repo#1"},
+		{name: "trailing hyphen in owner", linkPR: "owner-/repo#1"},
 	}
 
 	for _, tt := range tests {

--- a/cmd/linear/commands/issue/update_test.go
+++ b/cmd/linear/commands/issue/update_test.go
@@ -322,11 +322,6 @@ func TestRunUpdate_EstimatePayload(t *testing.T) {
 }
 
 func TestRunUpdate_LinkPR(t *testing.T) {
-	// wantURL values for short-format inputs reflect the current
-	// owner/repo#N -> https://github.com/owner/repo#N conversion, not a
-	// canonical GitHub PR URL shape.
-	// TODO(#115): fix the conversion to produce /pull/N and update these
-	// expectations together with it.
 	tests := []struct {
 		name    string
 		args    []string
@@ -335,17 +330,22 @@ func TestRunUpdate_LinkPR(t *testing.T) {
 		{
 			name:    "link-pr with estimate in nullable path",
 			args:    []string{"ENG-123", "--estimate=5", "--link-pr=owner/repo#1"},
-			wantURL: "https://github.com/owner/repo#1",
+			wantURL: "https://github.com/owner/repo/pull/1",
 		},
 		{
 			name:    "link-pr with assignee none in nullable path",
 			args:    []string{"ENG-123", "--assignee=none", "--link-pr=owner/repo#2"},
-			wantURL: "https://github.com/owner/repo#2",
+			wantURL: "https://github.com/owner/repo/pull/2",
 		},
 		{
 			name:    "link-pr with title in standard path",
 			args:    []string{"ENG-123", "--title=x", "--link-pr=owner/repo#3"},
-			wantURL: "https://github.com/owner/repo#3",
+			wantURL: "https://github.com/owner/repo/pull/3",
+		},
+		{
+			name:    "link-pr with hyphenated owner and dotted repo",
+			args:    []string{"ENG-123", "--title=x", "--link-pr=my-org/repo.name#45"},
+			wantURL: "https://github.com/my-org/repo.name/pull/45",
 		},
 		{
 			name:    "link-pr with full URL passed through unchanged",
@@ -379,6 +379,48 @@ func TestRunUpdate_LinkPR(t *testing.T) {
 			}
 			if got := captured.LinkPRVars["issueId"]; got != "issue-123" {
 				t.Errorf("issueId = %v, want %q", got, "issue-123")
+			}
+		})
+	}
+}
+
+// A short-format value that is not owner/repo#number must be rejected
+// instead of being blindly prefixed with https://github.com/.
+func TestRunUpdate_LinkPRInvalidFormat(t *testing.T) {
+	tests := []struct {
+		name   string
+		linkPR string
+	}{
+		{name: "bare word", linkPR: "banana"},
+		{name: "missing number", linkPR: "owner/repo"},
+		{name: "non-numeric number", linkPR: "owner/repo#abc"},
+		{name: "extra path segment", linkPR: "owner/repo/extra#1"},
+		{name: "leading hyphen in owner", linkPR: "-owner/repo#1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, captured := captureUpdateServer(t)
+			defer server.Close()
+			factory := func() (*linear.Client, error) {
+				return linear.NewClient("test_api_key", linear.WithBaseURL(server.URL))
+			}
+
+			cmd := NewUpdateCommand(factory)
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs([]string{"ENG-123", "--title=x", "--link-pr=" + tt.linkPR})
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("Execute() succeeded, want invalid --link-pr error")
+			}
+			if !strings.Contains(err.Error(), "invalid --link-pr value") {
+				t.Errorf("error = %v, want it to mention invalid --link-pr value", err)
+			}
+			if captured.LinkPRVars != nil {
+				t.Errorf("AttachmentLinkGitHubPR was called with %v, want no call", captured.LinkPRVars)
 			}
 		})
 	}

--- a/cmd/linear/commands/issue/update_test.go
+++ b/cmd/linear/commands/issue/update_test.go
@@ -348,6 +348,11 @@ func TestRunUpdate_LinkPR(t *testing.T) {
 			wantURL: "https://github.com/my-org/repo.name/pull/45",
 		},
 		{
+			name:    "link-pr with dot-leading repo",
+			args:    []string{"ENG-123", "--title=x", "--link-pr=myorg/.github#12"},
+			wantURL: "https://github.com/myorg/.github/pull/12",
+		},
+		{
 			name:    "link-pr with full URL passed through unchanged",
 			args:    []string{"ENG-123", "--estimate=5", "--link-pr=https://github.com/owner/repo/pull/4"},
 			wantURL: "https://github.com/owner/repo/pull/4",
@@ -397,6 +402,7 @@ func TestRunUpdate_LinkPRInvalidFormat(t *testing.T) {
 		{name: "extra path segment", linkPR: "owner/repo/extra#1"},
 		{name: "leading hyphen in owner", linkPR: "-owner/repo#1"},
 		{name: "trailing hyphen in owner", linkPR: "owner-/repo#1"},
+		{name: "schemeless full PR path", linkPR: "owner/repo/pull/5"},
 	}
 
 	for _, tt := range tests {

--- a/cmd/linear/commands/issue/update_test.go
+++ b/cmd/linear/commands/issue/update_test.go
@@ -429,6 +429,9 @@ func TestRunUpdate_LinkPRInvalidFormat(t *testing.T) {
 			if captured.LinkPRVars != nil {
 				t.Errorf("AttachmentLinkGitHubPR was called with %v, want no call", captured.LinkPRVars)
 			}
+			if captured.Input != nil {
+				t.Errorf("UpdateIssue ran with input %v, want no mutation for an invalid --link-pr", captured.Input)
+			}
 		})
 	}
 }


### PR DESCRIPTION
`linear issue update --link-pr owner/repo#123` converted the short format by blindly prefixing `https://github.com/`, producing `https://github.com/owner/repo#123` — a repo-root URL with a fragment. The attachment Linear received pointed at the repository, not the pull request.

`linkGitHubPR` now parses the short format explicitly and emits the canonical `https://github.com/owner/repo/pull/123`. Values that match neither `owner/repo#number` nor a full URL (`://`) are rejected with an error naming the accepted formats, instead of being silently prefixed into a broken attachment.

**Behavior change:** schemeless inputs that only "worked" through the blind prefixing — e.g. `owner/repo/pull/5` or a bare `banana` — now fail with `invalid --link-pr value`. The flag has always documented `owner/repo#number or full URL` as the accepted formats; anything else previously created a silently wrong attachment.

The regex is deliberately asymmetric to match GitHub's naming rules: owners can't start or end with a hyphen, while repo names permit `.`, `_`, and `-` anywhere (e.g. `myorg/.github#12` is valid). Full URLs pass through unchanged, as before.

Tests: the `TestRunUpdate_LinkPR` expectations pinned to the old fragment shape in #113 (with a TODO pointing here) now assert `/pull/N` in both the standard and nullable update paths, plus a new `TestRunUpdate_LinkPRInvalidFormat` table covering rejection cases.

Fixes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)