### PR TITLE
fix(issue): allow --link-pr without other update fields

### DIFF
--- a/cmd/linear/commands/issue/update.go
+++ b/cmd/linear/commands/issue/update.go
@@ -254,6 +254,27 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 	}
 
 	if !updated {
+		// --link-pr on its own is a valid operation: link the PR without
+		// running an update mutation, then print the issue as usual.
+		if prURL, _ := cmd.Flags().GetString("link-pr"); prURL != "" {
+			if err := linkGitHubPR(ctx, cmd, client, resolvedIssueID); err != nil {
+				return err
+			}
+			issue, err := client.Issue(ctx, resolvedIssueID)
+			if err != nil {
+				return fmt.Errorf("failed to fetch issue: %w", err)
+			}
+			// Print the same shape the update mutation returns so the
+			// command's output schema does not depend on which flags ran.
+			return formatter.FormatJSON(cmd.OutOrStdout(), &intgraphql.UpdateIssue_IssueUpdate_Issue{
+				Description: issue.Description,
+				ID:          issue.ID,
+				Identifier:  issue.Identifier,
+				Priority:    issue.Priority,
+				Title:       issue.Title,
+				UpdatedAt:   issue.UpdatedAt,
+			}, true)
+		}
 		return fmt.Errorf("no fields to update specified")
 	}
 

--- a/cmd/linear/commands/issue/update.go
+++ b/cmd/linear/commands/issue/update.go
@@ -262,7 +262,7 @@ func runUpdate(cmd *cobra.Command, client *linear.Client, issueID string) error 
 			}
 			issue, err := client.Issue(ctx, resolvedIssueID)
 			if err != nil {
-				return fmt.Errorf("failed to fetch issue: %w", err)
+				return fmt.Errorf("PR linked, but failed to fetch issue: %w", err)
 			}
 			// Print the same shape the update mutation returns so the
 			// command's output schema does not depend on which flags ran.

--- a/cmd/linear/commands/issue/update_test.go
+++ b/cmd/linear/commands/issue/update_test.go
@@ -428,3 +428,92 @@ func TestRunUpdate_LinkPRError(t *testing.T) {
 		})
 	}
 }
+
+// --link-pr with no other flags must link the PR without running an
+// IssueUpdate mutation, then print the issue.
+func TestRunUpdate_LinkPROnly(t *testing.T) {
+	t.Run("links PR and skips update mutation", func(t *testing.T) {
+		server, captured := captureUpdateServer(t)
+		defer server.Close()
+		factory := func() (*linear.Client, error) {
+			return linear.NewClient("test_api_key", linear.WithBaseURL(server.URL))
+		}
+
+		cmd := NewUpdateCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetArgs([]string{"ENG-123", "--link-pr=owner/repo#1"})
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+
+		if captured.Input != nil {
+			t.Errorf("UpdateIssue mutation ran with input %v, want no mutation", captured.Input)
+		}
+		if captured.LinkPRVars == nil {
+			t.Fatal("no AttachmentLinkGitHubPR mutation captured")
+		}
+		if got := captured.LinkPRVars["issueId"]; got != "issue-123" {
+			t.Errorf("issueId = %v, want %q", got, "issue-123")
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("Output should be valid JSON: %v", err)
+		}
+		if got := result["identifier"]; got != "ENG-123" {
+			t.Errorf("output identifier = %v, want %q (the fetched issue)", got, "ENG-123")
+		}
+		if _, exists := result["assignee"]; exists {
+			t.Error("output contains assignee key; want the update-result shape, not the full GetIssue shape")
+		}
+	})
+
+	t.Run("no flags at all still errors", func(t *testing.T) {
+		server, _ := captureUpdateServer(t)
+		defer server.Close()
+		factory := func() (*linear.Client, error) {
+			return linear.NewClient("test_api_key", linear.WithBaseURL(server.URL))
+		}
+
+		cmd := NewUpdateCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		cmd.SetArgs([]string{"ENG-123"})
+
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("Execute() succeeded, want no-fields error")
+		}
+		if !strings.Contains(err.Error(), "no fields to update specified") {
+			t.Errorf("error = %v, want no-fields error", err)
+		}
+	})
+
+	t.Run("link failure surfaces as error", func(t *testing.T) {
+		server, captured := captureUpdateServerWithLinkPR(t, `{"data":{"attachmentLinkGitHubPR":{"success":false}}}`)
+		defer server.Close()
+		factory := func() (*linear.Client, error) {
+			return linear.NewClient("test_api_key", linear.WithBaseURL(server.URL))
+		}
+
+		cmd := NewUpdateCommand(factory)
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		cmd.SetArgs([]string{"ENG-123", "--link-pr=owner/repo#1"})
+
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected error when AttachmentLinkGitHubPR fails")
+		}
+		if !strings.Contains(err.Error(), "failed to link GitHub PR") {
+			t.Errorf("error = %q, want it to mention failing to link the GitHub PR", err)
+		}
+		if captured.Input != nil {
+			t.Errorf("UpdateIssue mutation ran with input %v, want no mutation", captured.Input)
+		}
+	})
+}

--- a/cmd/linear/commands/issue/update_test.go
+++ b/cmd/linear/commands/issue/update_test.go
@@ -465,6 +465,12 @@ func TestRunUpdate_LinkPROnly(t *testing.T) {
 		if got := result["identifier"]; got != "ENG-123" {
 			t.Errorf("output identifier = %v, want %q (the fetched issue)", got, "ENG-123")
 		}
+		if got := result["id"]; got != "issue-123" {
+			t.Errorf("output id = %v, want %q", got, "issue-123")
+		}
+		if got := result["title"]; got != "Test Issue" {
+			t.Errorf("output title = %v, want %q", got, "Test Issue")
+		}
 		if _, exists := result["assignee"]; exists {
 			t.Error("output contains assignee key; want the update-result shape, not the full GetIssue shape")
 		}

--- a/cmd/linear/commands/issue/update_test.go
+++ b/cmd/linear/commands/issue/update_test.go
@@ -442,7 +442,7 @@ func TestRunUpdate_LinkPROnly(t *testing.T) {
 		cmd := NewUpdateCommand(factory)
 		var buf bytes.Buffer
 		cmd.SetOut(&buf)
-		cmd.SetArgs([]string{"ENG-123", "--link-pr=owner/repo#1"})
+		cmd.SetArgs([]string{"ENG-123", "--link-pr=https://github.com/owner/repo/pull/1"})
 
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute() error = %v", err)
@@ -456,6 +456,9 @@ func TestRunUpdate_LinkPROnly(t *testing.T) {
 		}
 		if got := captured.LinkPRVars["issueId"]; got != "issue-123" {
 			t.Errorf("issueId = %v, want %q", got, "issue-123")
+		}
+		if got := captured.LinkPRVars["url"]; got != "https://github.com/owner/repo/pull/1" {
+			t.Errorf("url = %v, want %q", got, "https://github.com/owner/repo/pull/1")
 		}
 
 		var result map[string]any
@@ -517,6 +520,9 @@ func TestRunUpdate_LinkPROnly(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "failed to link GitHub PR") {
 			t.Errorf("error = %q, want it to mention failing to link the GitHub PR", err)
+		}
+		if captured.LinkPRVars == nil {
+			t.Error("no AttachmentLinkGitHubPR mutation captured; error came from the wrong place")
 		}
 		if captured.Input != nil {
 			t.Errorf("UpdateIssue mutation ran with input %v, want no mutation", captured.Input)


### PR DESCRIPTION
`linear issue update ENG-123 --link-pr owner/repo#1` with no other flags failed with `no fields to update specified`: the guard in `runUpdate` executed before the PR-link block, so linking a PR without also changing a field was impossible. The README's own example (`issue update ENG-123 --link-pr=owner/repo#123`) is exactly this invocation.

When `--link-pr` is the only flag, the command now skips the `IssueUpdate` mutation entirely, creates the attachment, then fetches the issue and prints it mapped into the update-result shape — so the command's output schema is identical whether or not a field update ran. Bare `issue update ENG-123` with no flags at all still errors as before.

**Behavior change:** `--link-pr` alone was previously an error and now succeeds. This makes the documented behavior real rather than changing any documented contract.

Tests: new `TestRunUpdate_LinkPROnly` pins the contract — no `IssueUpdate` mutation runs, the attachment mutation fires with the resolved issue ID, output is the update-result JSON shape for the fetched issue, no-flags invocations still error, and a failed link surfaces as an error.

Independent of #123 (the short-format URL fix, issue #115); both branch off main and touch different regions of `update.go`.

Fixes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)