### PR TITLE
chore(deps): bump Go to 1.26.5 to clear stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chainguard-sandbox/go-linear/v2
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Yamashou/gqlgenc v0.33.0


### PR DESCRIPTION
go1.26.4's `crypto/tls` is affected by [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) (Encrypted Client Hello privacy leak), which fails the Vulnerability Scan CI check on every branch — including main and the open PRs (#123, #124).

One line: bump the `go` directive to 1.26.5. Every workflow reads the toolchain from `go.mod` (`go-version-file`), and the test matrix's `'1.26'` with `check-latest: true` already resolves to the latest patch, so no workflow changes are needed. `go.sum` is untouched, as expected for a stdlib-only bump.

Verified locally on go1.26.5: full test suite passes (41 packages) and `govulncheck ./...` reports zero vulnerabilities affecting the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)