### PR TITLE
fix(ci): pin schema acquisition to release tags, drop master curls

### DIFF
--- a/.github/workflows/sync-check.yaml
+++ b/.github/workflows/sync-check.yaml
@@ -28,10 +28,38 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Fetch upstream schema
+      - name: Resolve latest upstream release
+        id: upstream
         run: |
-          # Download just the schema file (no full clone)
-          curl -sSL https://raw.githubusercontent.com/linear/linear/master/packages/sdk/src/schema.graphql \
+          # Resolve the newest @linear/sdk release tag and its commit SHA via
+          # the git protocol, then fetch the schema at that immutable SHA.
+          # Comparing against a release (not the moving master branch) matches
+          # what make sync-upstream targets and avoids an unpinned download.
+          TAGS=$(git ls-remote --tags https://github.com/linear/linear.git 'refs/tags/@linear/sdk@*')
+          LATEST_TAG=$(printf '%s\n' "$TAGS" \
+            | sed -n 's|.*\trefs/tags/\(@linear/sdk@[0-9][0-9.]*\)$|\1|p' \
+            | sort -t '@' -k 3 -V | tail -1)
+          if [ -z "$LATEST_TAG" ]; then
+            echo "::error::could not resolve latest @linear/sdk release tag"
+            exit 1
+          fi
+          # Annotated tags list a dereferenced ^{} commit; prefer it.
+          SHA=$(printf '%s\n' "$TAGS" | awk -v t="refs/tags/${LATEST_TAG}^{}" '$2==t {print $1}')
+          if [ -z "$SHA" ]; then
+            SHA=$(printf '%s\n' "$TAGS" | awk -v t="refs/tags/${LATEST_TAG}" '$2==t {print $1}')
+          fi
+          {
+            echo "tag=$LATEST_TAG"
+            echo "sha=$SHA"
+            echo "version=${LATEST_TAG##*@}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Latest upstream release: $LATEST_TAG ($SHA)"
+
+      - name: Fetch upstream schema at release SHA
+        env:
+          UPSTREAM_SHA: ${{ steps.upstream.outputs.sha }}
+        run: |
+          curl -sSL "https://raw.githubusercontent.com/linear/linear/${UPSTREAM_SHA}/packages/sdk/src/schema.graphql" \
             -o upstream-schema.graphql
 
       - name: Compare schemas
@@ -55,21 +83,11 @@ jobs:
             echo "✅ Schema is up to date"
           fi
 
-      - name: Get upstream version
-        if: steps.check.outputs.updates == 'true'
-        id: version
-        run: |
-          # Fetch package.json to get version
-          VERSION=$(curl -sSL https://raw.githubusercontent.com/linear/linear/master/packages/sdk/package.json | \
-            jq -r '.version')
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Upstream version: $VERSION"
-
       - name: Create issue if updates found
         if: steps.check.outputs.updates == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          UPSTREAM_VERSION: ${{ steps.version.outputs.version }}
+          UPSTREAM_VERSION: ${{ steps.upstream.outputs.version }}
         with:
           script: |
             const version = process.env.UPSTREAM_VERSION;

--- a/.github/workflows/sync-check.yaml
+++ b/.github/workflows/sync-check.yaml
@@ -47,8 +47,8 @@ jobs:
           if [ -z "$SHA" ]; then
             SHA=$(printf '%s\n' "$TAGS" | awk -v t="refs/tags/${LATEST_TAG}" '$2==t {print $1}')
           fi
-          if [ -z "$SHA" ]; then
-            echo "::error::could not resolve commit SHA for ${LATEST_TAG}"
+          if ! printf '%s\n' "$SHA" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "::error::could not resolve a valid commit SHA for ${LATEST_TAG} (got: ${SHA})"
             exit 1
           fi
           {

--- a/.github/workflows/sync-check.yaml
+++ b/.github/workflows/sync-check.yaml
@@ -48,6 +48,10 @@ jobs:
           if [ -z "$SHA" ]; then
             SHA=$(printf '%s\n' "$TAGS" | awk -v t="refs/tags/${LATEST_TAG}" '$2==t {print $1}')
           fi
+          if [ -z "$SHA" ]; then
+            echo "::error::could not resolve commit SHA for ${LATEST_TAG}"
+            exit 1
+          fi
           {
             echo "tag=$LATEST_TAG"
             echo "sha=$SHA"
@@ -59,7 +63,7 @@ jobs:
         env:
           UPSTREAM_SHA: ${{ steps.upstream.outputs.sha }}
         run: |
-          curl -sSL "https://raw.githubusercontent.com/linear/linear/${UPSTREAM_SHA}/packages/sdk/src/schema.graphql" \
+          curl -sSL --fail "https://raw.githubusercontent.com/linear/linear/${UPSTREAM_SHA}/packages/sdk/src/schema.graphql" \
             -o upstream-schema.graphql
 
       - name: Compare schemas

--- a/.github/workflows/sync-check.yaml
+++ b/.github/workflows/sync-check.yaml
@@ -17,7 +17,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,8 @@ make sync-upstream   # fetch latest schema, regenerate code, run tests
 
 Review the diff carefully — new types are added to `internal/graphql/models.go` and `schema.graphql`. Verify that removed or renamed upstream types don't break existing queries in `queries/`.
 
+This is the only sanctioned way to update `schema.graphql`: the submodule pins an exact release tag whose commit hash is recorded in git, so the schema's provenance is verifiable. Never hand-download the schema from the upstream repo's `master` branch — a moving ref with no integrity check. `make schema` is an alias for the submodule copy, and the weekly `sync-check` workflow compares against the latest release tag by commit SHA for the same reason.
+
 ## MCP Tool Documentation
 
 Every token in MCP tool descriptions is permanent overhead for the entire session. Optimize ruthlessly.

--- a/Makefile
+++ b/Makefile
@@ -284,11 +284,9 @@ download:  ## Download dependencies
 # Schema management
 #
 
-schema:  ## Download Linear GraphQL schema
-	@echo "Downloading Linear GraphQL schema..."
-	@mkdir -p .
-	@curl -sSL https://raw.githubusercontent.com/linear/linear/master/packages/sdk/src/schema.graphql -o schema.graphql
-	@echo "✓ Schema downloaded to schema.graphql"
+# The schema is only ever updated from the pinned upstream submodule so the
+# source is an exact, hash-recorded release tag — never a moving branch.
+schema: sync-schema  ## Copy the GraphQL schema from the pinned upstream submodule
 
 #
 # Upstream sync (maintainers only)


### PR DESCRIPTION
The repo had two schema-acquisition paths with different trust levels: `make sync-upstream` copies from the `upstream` submodule pinned at an exact release tag, while `make schema` and the weekly `sync-check` workflow curled `schema.graphql` (and `package.json`) straight from the upstream repo's moving `master` branch with no integrity check (CWE-494) — `make schema` would silently overwrite the pinned schema with unreleased content.

Changes:

- **`make schema`** is now an alias for the submodule copy, behind the existing sync-mode guard. There is exactly one schema source: a release tag whose commit hash is recorded in git.
- **`sync-check.yaml`** resolves the newest `@linear/sdk` release tag via `git ls-remote` and fetches the schema at that tag's immutable commit SHA. The version comes from the tag name, removing the second unpinned curl of `package.json`. Side benefit: drift detection now tracks *releases* instead of unreleased `master` churn, matching what `make sync-upstream` actually targets.
- **CONTRIBUTING.md** documents the submodule as the only sanctioned schema source.

Verified: the tag-resolution script tested against the live upstream resolves `@linear/sdk@88.3.0` at `8335e09` — the same commit the submodule pins in #126 — and the SHA-pinned fetch returns the schema. actionlint and zizmor pass on the workflow.

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)