### PR TITLE
ci(sync-check): enforce egress allowlist with harden-runner block mode

### DIFF
--- a/.github/workflows/sync-check.yaml
+++ b/.github/workflows/sync-check.yaml
@@ -24,8 +24,10 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
+            *.githubapp.com:443
             api.github.com:443
             github.com:443
+            objects.githubusercontent.com:443
             raw.githubusercontent.com:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/sync-check.yaml
+++ b/.github/workflows/sync-check.yaml
@@ -19,10 +19,14 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden the runner (block non-allowlisted outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            raw.githubusercontent.com:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
`sync-check.yaml` ran harden-runner with `egress-policy: audit`, while sibling workflows (`actionlint.yaml`, `zizmor.yaml`) already use `block`. This job's legitimate egress is a small, known set — `github.com:443` (checkout, `git ls-remote`), `api.github.com:443` (issue creation via github-script), and `raw.githubusercontent.com:443` (schema fetch) — so blocking everything else enforces at the network layer what #128 establishes at the tooling layer: no unpinned download path can quietly return.

The allowlist follows the sibling workflows' pattern and covers the workflow both before and after #128 (both versions fetch from the same endpoints), so merge order doesn't matter. Worth validating with a `workflow_dispatch` run after merging — harden-runner's annotations will flag anything the allowlist missed.

Complements #128 and #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)